### PR TITLE
feat(refactor): Refactor the package for reliability

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,9 +45,9 @@ jobs:
         with:
           python-version: 3.7
       - name: set up node  # we need node for for semantic release
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v4
         with:
-          node-version: 14.2.0
+          node-version: 22.2.0
       - name: install python dependencies
         run: |
           python -m pip install --upgrade pip
@@ -59,8 +59,8 @@ jobs:
       - name: run semantic release
         id: new_release
         run: |
-          nextRelease="`npx semantic-release@^17.0.0 --dryRun | grep -oP 'Published release \K.*? ' || true`"
-          npx semantic-release@^17.0.0
+          nextRelease="`npx semantic-release@^23.1.1 --dryRun | grep -oP 'Published release \K.*? ' || true`"
+          npx semantic-release@^23.1.1
           echo "::set-output name=tag::$nextRelease"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,7 +2,13 @@
     "plugins": [
         "@semantic-release/commit-analyzer",
         "@semantic-release/release-notes-generator",
-        "@semantic-release/github",
+        [
+            "@semantic-release/github",
+            {
+                "successComment": false,
+                "failTitle": false
+            }
+        ],
         [
             "@semantic-release/exec",
             {

--- a/ladybug_geometry_polyskel/polygraph.py
+++ b/ladybug_geometry_polyskel/polygraph.py
@@ -1,14 +1,12 @@
 # coding=utf-8
-"""
-Implementation of a Directed Graph.
-"""
-
+"""Implementation of a Directed Graph data structure."""
 from __future__ import division
+import math
 
-# Geometry classes
-from ladybug_geometry.geometry2d.line import LineSegment2D
-from ladybug_geometry import intersection2d
-from math import log10
+from ladybug_geometry.geometry2d import LineSegment2D, Polygon2D
+from ladybug_geometry.intersection2d import intersect_line2d_infinite
+
+from .polyskel import skeleton_as_edge_list, _intersect_skeleton_segments
 
 
 def _vector2hash(vector, tol):
@@ -22,31 +20,32 @@ def _vector2hash(vector, tol):
         Hash of vector as a string of rounded coordinates.
     """
     try:
-        rtol = int(log10(tol)) * -1
+        rtol = (int(math.log10(tol)) * -1)
     except ValueError:
         rtol = 0
-
-    return str((round(vector.x, rtol), round(vector.y, rtol)))
+    # avoid cases of signed zeros messing with keys
+    x_val = 0.0 if vector.x == 0 else vector.x
+    y_val = 0.0 if vector.y == 0 else vector.y
+    return str((round(x_val, rtol), round(y_val, rtol)))
 
 
 class _Node(object):
     """Private class to handle nodes in PolygonDirectedGraph.
 
-        Args:
-            val: A Point2D object.
-            key: Hash of Point2D object.
-            order: integer counting order of Node (based on dg propagation)
-            adj_lst: list of keys adjacent to this node.
-            exterior: Node boundary condition. None if not set by user, else True
-                or False according to user.
+    Args:
+        val: A Point2D object.
+        key: Hash of Point2D object.
+        order: integer counting order of the Node (based on dg propagation)
+        adj_lst: list of keys adjacent to this node.
+        exterior: Node boundary condition. None if not set by user, else True
+            or False according to user.
 
-        Properties:
-        * pt: A Point2D object.
-        * key: Hash of Point2D object.
-        * adj_lst: A list of keys adjacent to this node.
-        * exterior: Node boundary condition. None if not set by user, else True or
-            False according to user.
-        * adj_count: Number of adjacent nodes to this node.
+    Properties:
+        * pt
+        * key
+        * adj_lst
+        * exterior
+        * adj_count
     """
     __slots__ = ('key', 'pt', '_order', 'adj_lst', 'exterior')
 
@@ -63,47 +62,55 @@ class _Node(object):
         # node/edge properties.
         self.exterior = exterior
 
-    def __repr__(self):
-        return '{}: {}'.format(self._order, self.key)
-
     @property
     def adj_count(self):
         """Number of adjacent nodes"""
         return len(self.adj_lst)
 
+    def __hash__(self):
+        return hash(self.key)
+
+    def __eq__(self, other):
+        return isinstance(other, _Node) and \
+            self.key == other.key
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return '{}: {}'.format(self._order, self.key)
+
 
 class PolygonDirectedGraph(object):
-    """A directed graph for point and edge adjacency relationships.
+    """A directed graph data structure for point relationships.
 
-    This class assumes that exterior edges are naked (unidirectional), oriented
-    counter-clockwise, and interior edges are bidirectional.
+    The PolygonDirectedGraph effectively represents the network of a straight
+    skeleton and assists with finding the shortest pathways through it. It also
+    helps differentiate interior from exterior parts of the graph. Typically,
+    interior pathways are bi-directional in the graph while exterior pathways
+    are uni-directional.
 
     Args:
-        tol: floating point precision used for hashing points.
+        tolerance: Tolerance for point equivalence. (Default: 1e-5). This is used
+            for hashing points within the network.
 
     Properties:
-        * outer_root_key: Root key for outside exterior boundary (i.e not holes).
-        * hole_root_keys: List of root keys for inside exterior boundary (holes).
-        * num_nodes: Number of nodes in graph.
+        * node_count: Integer for the number of nodes in graph.
         * nodes: An iterable of nodes in graph.
         * ordered_nodes: An iterable of nodes in graph in order they were added.
-        * exterior_cycles: A list of unidirectional edge arrays.
+        * connection_segments: List of LineSegment2D for the node connections
+        * outer_root_node: A node for the outer root key
+        * hole_root_nodes: A list of nodes for the hole root keys
+        * is_intersect_topology: A boolean for whether the graph self-intersects
     """
 
     def __init__(self, tol):
         """Initialize a PolygonDirectedGraph."""
         self._directed_graph = {}
         self._tol = tol
-        self.outer_root_key = None
-        self.hole_root_keys = []
-
-    def __repr__(self):
-        s = ''
-        for n in self.ordered_nodes:
-            s += '{}, [{}]\n'.format(
-                n.pt.to_array(),
-                ', '.join([str(_n.pt.to_array()) for _n in n.adj_lst]))
-        return s
+        self.outer_root_key = None  # will be set during skeleton creation
+        self.hole_root_keys = []  # will be set during skeleton creation
+        self.is_intersect_topology = None  # will be set during skeleton creation
 
     @classmethod
     def from_polygon(cls, polygon, tol):
@@ -123,18 +130,15 @@ class PolygonDirectedGraph(object):
             loop: Optional parameter to connect 1d array
             tol: Tolerance for point equivalence.
         """
-
         dg = cls(tol)
         for i in range(len(point_array) - 1):
-            dg.add_node(point_array[i], [point_array[i + 1]], exterior=True)
-
+            dg.add_node(point_array[i], [point_array[i + 1]], exterior=None)
         if loop:
-            dg.add_node(point_array[-1], [point_array[0]], exterior=True)
-
+            dg.add_node(point_array[-1], [point_array[0]], exterior=None)
         return dg
 
     @property
-    def num_nodes(self):
+    def node_count(self):
         return len(self.nodes)
 
     @property
@@ -150,52 +154,28 @@ class PolygonDirectedGraph(object):
         return nodes
 
     @property
-    def exterior_cycles(self):
-        """Computes all exterior boundaries.
+    def outer_root_node(self):
+        """Get the node of the outer boundary root."""
+        return self.node(self.outer_root_key)
 
-        Returns:
-            List of boundaries as list of nodes. The first polygon will
-            be the outer exterior edge (in counter-clockwise order), and
-            subsequent edges will be the edges of the holes in the graph
-            (in clockwise order).
-        """
+    @property
+    def hole_root_nodes(self):
+        """Get a list of nodes for the roots of the holes."""
+        return [self.node(hole_key) for hole_key in self.hole_root_keys]
 
-        exterior_poly_lst = []
-        exterior_check = {}
-
-        for root_node in self.ordered_nodes:
-
-            # Store node in check
-            exterior_check[root_node.key] = None
-
-            # Get next exterior adjacent node
-            next_node = self.next_exterior_node(root_node)
-
-            is_valid = (next_node is not None) and \
-                (next_node.key not in exterior_check)
-
-            if not is_valid:
-                continue
-
-            # Create list of exterior points
-            exterior_poly = [root_node]
-            # Add to dict to prevent repetition
-            exterior_check[next_node.key] = None
-
-            # CWM: hard-code a max iteration count to avoid endless loops
-            MAX_ITER_COUNT = 10000
-            iter_i = 0
-            while next_node.key != root_node.key:
-                exterior_poly.append(next_node)
-                exterior_check[next_node.key] = None
-                next_node = self.next_exterior_node(next_node)
-                iter_i += 1
-                if iter_i > MAX_ITER_COUNT:
-                    return []
-
-            exterior_poly_lst.append(exterior_poly)
-
-        return exterior_poly_lst
+    @property
+    def connection_segments(self):
+        """Get a list of LineSegment2D for the node connections in the graph."""
+        connections = []
+        for node in self.nodes:
+            for conn_key in node.adj_lst:
+                try:
+                    conn_seg = LineSegment2D.from_end_points(
+                        node.pt, self._directed_graph[conn_key])
+                    connections.append(conn_seg)
+                except KeyError:
+                    pass  # broken connection
+        return connections
 
     def node(self, key):
         """Retrieves the node based on passed value.
@@ -206,11 +186,10 @@ class PolygonDirectedGraph(object):
         Returns:
             The node for the passed key.
         """
-
         try:
             return self._directed_graph[key]
         except KeyError:
-            return None
+            return None  # broken connection
 
     def add_adj(self, node, adj_val_lst):
         """Adds nodes to node.adj_lst.
@@ -241,73 +220,61 @@ class PolygonDirectedGraph(object):
         """
         node.adj_lst = [n for n in node.adj_lst if n.key not in set(adj_key_lst)]
 
-    def _add_node(self, key, val, exterior=None):
-        """If key doesn't exist, add to dg.
-
-        Helper function for add_node.
-        """
-        if key not in self._directed_graph:
-            self._directed_graph[key] = _Node(key, val, self.num_nodes, [], exterior)
-        return self._directed_graph[key]
-
     def add_node(self, val, adj_lst, exterior=None):
-        """Consumes a polygon point, and computes its key value, and adds it in the
+        """Add a node into the PolygonDirectedGraph.
+
+        This method consumes a Point2D, computes its key value, and adds it in the
         graph if it doesn't exist. If it does exist it appends adj_lst to existing pt.
 
         Args:
-            val: A Point2D object
-            adj_lst: A list of Point2D objects
+            val: A Point2D object.
+            adj_lst: A list of Point2D objects adjacent to the node.
+            exterior: Optional boolean for exterior attribute.
 
         Returns:
             The hashed key from the existing or new node.
         """
-
-        # Get key
-        key = _vector2hash(val, self._tol)
-
-        # Get node if it exists
-        self._add_node(key, val, exterior)
-
+        key = _vector2hash(val, self._tol)  # get key
+        self._add_node(key, val, exterior)  # get node if it exists
         node = self._directed_graph[key]
-
-        # Add the adj_lst to dg, and leave exterior None
-        self.add_adj(node, adj_lst)
-
-        # If pass exterior boolean, change node attribute
+        self.add_adj(node, adj_lst)  # add the adj_lst to dg
+        # if the exterior boolean was passed, change the node attribute
         if exterior is not None:
             node.exterior = exterior
-
         return node.key
 
-    def insert_node(self, node, new_val, next_node, exterior=None):
+    def _add_node(self, key, val, exterior=None):
+        """Helper function for add_node. If key doesn't exist, add to dg."""
+        if key not in self._directed_graph:
+            self._directed_graph[key] = _Node(key, val, self.node_count, [], exterior)
+        return self._directed_graph[key]
+
+    def insert_node(self, base_node, new_val, next_node, exterior=None):
         """Insert node in the middle of an edge defined by node and next_node.
 
         Args:
-            node: _Node to left.
-            new_val: Value for middle node.
-            next_node: _Node to right.
+            base_node: _Node object to the left.
+            new_val:  A Point2D object for the new node in the middle.
+            next_node: _Node object to the right.
             exterior: Optional boolean for exterior attribute.
 
         Returns:
             key of new_val node.
         """
-        # Add new_val as a node, with next_node as an adjacency
+        # add new_val as a node, with next_node as an adjacency
         new_key = self.add_node(new_val, [next_node.pt], exterior=exterior)
+        # update parent by adding new adjacency, and removing old adjacency
+        self.add_adj(base_node, [self.node(new_key).pt])
 
-        # Update parent by adding new adjacency, and removing old adjacency
-        self.add_adj(node, [self.node(new_key).pt])
-
-        # Edge case where the new point is coincident to parent or next_point.
-        # This occurs when intersection passes through a corner.
-        if (new_key == next_node.key) or (new_key == node.key):
+        # catch the edge case where the new point is coincident to parent or next_point.
+        # this occurs when intersection passes through a corner.
+        if (new_key == next_node.key) or (new_key == base_node.key):
             return new_key
-
-        self.remove_adj(node, [next_node.key])
-
+        self.remove_adj(base_node, [next_node.key])
         return new_key
 
     def node_exists(self, key):
-        """True if node in directed graph else False"""
+        """Check if a node is in the graph. True if node in directed graph else False."""
         return key in self._directed_graph
 
     def pt_exists(self, pt):
@@ -316,7 +283,7 @@ class PolygonDirectedGraph(object):
         return self.node_exists(_vector2hash(pt, self._tol))
 
     def polygon_exists(self, polygon):
-        """Check if polygon is in directed graph.
+        """Check if polygon is in the directed graph.
 
         Args:
             polygons: A Polygon2D object.
@@ -352,12 +319,11 @@ class PolygonDirectedGraph(object):
             N x N square matrix where N is number of nodes.
         """
         nodes = self.ordered_nodes
+        # initialize a mtx with no adjacencies
+        amtx = [[0 for i in range(self.node_count)]
+                for j in range(self.node_count)]
 
-        # Initialize amtx with no adjacencies
-        amtx = [[0 for i in range(self.num_nodes)]
-                for j in range(self.num_nodes)]
-
-        for i in range(self.num_nodes):
+        for i in range(self.node_count):
             adj_indices = [adj._order for adj in nodes[i].adj_lst]
             for adj_idx in adj_indices:
                 amtx[i][adj_idx] = 1
@@ -370,38 +336,37 @@ class PolygonDirectedGraph(object):
         return {i: node.key for i, node in enumerate(self.ordered_nodes)}
 
     def intersect_graph_with_segment(self, segment):
-        """Update graph with intersection of partial segment that crosses through polygon.
+        """Update graph with intersection of partial segment crossing through polygon.
 
         Args:
-            segment: LineSegment2D to intersect. Does not need to be contained within
-            polygon.
+            segment: LineSegment2D to intersect with the graph. The LineSegment2D
+                does not need to be contained within polygon and will be intersected
+                infinitely.
         """
+        # loop through all nodes in the graph and find intersection points
         int_key_lst = []
-
         for node in self.ordered_nodes:
-
-            # Convert graph edge to trimming segment
+            # convert graph edge to trimming segment
             next_node = node.adj_lst[0]
             trim_seg = LineSegment2D.from_end_points(node.pt, next_node.pt)
-            int_pt = intersection2d.intersect_line2d_infinite(trim_seg, segment)
+            int_pt = intersect_line2d_infinite(trim_seg, segment)
 
-            # Add intersection point as new node in graph
+            # add intersection point as new node in graph
             if int_pt:
-                int_key = self.insert_node(
-                    node, int_pt, next_node, exterior=False)
+                int_key = self.insert_node(node, int_pt, next_node, exterior=False)
                 int_key_lst.append(int_key)
 
-        # Add intersection edges
+        # add intersection edges between the newly-found nodes
         if len(int_key_lst) == 2:
-            # Typical case with convex cases
-            # Make edge between intersection nodes
+            # typical case with convex cases
+            # make edge between intersection nodes
             n1, n2 = self.node(int_key_lst[0]), self.node(int_key_lst[1])
             self.add_node(n1.pt, [n2.pt], exterior=False)
             self.add_node(n2.pt, [n1.pt], exterior=False)
 
         elif len(int_key_lst) > 2:
-            # Edge case with concave geometry creates multiple intersections
-            # Sort distance and add adjacency
+            # edge case with concave geometry creates multiple intersections
+            # sort distance and add adjacency
             n = self.node(int_key_lst[0])
             distances = [(0, 0.0)]
 
@@ -414,10 +379,219 @@ class PolygonDirectedGraph(object):
             for i in range(len(distances) - 1):
                 k1, k2 = distances[i][0], distances[i + 1][0]
                 n1, n2 = self.node(int_key_lst[k1]), self.node(int_key_lst[k2])
-
-                # Add bidirection so the min cycle works
+                # add bi-direction so the min cycle works
                 self.add_node(n1.pt, [n2.pt], exterior=False)
                 self.add_node(n2.pt, [n1.pt], exterior=False)
+
+    def min_cycle(self, base_node, goal_node, ccw_only=False):
+        """Identify the shortest interior cycle between two exterior nodes.
+
+        Args:
+            base_node: The first exterior node of the edge.
+            goal_node: The end exterior node of the cycle that, together with
+                the base_node, constitutes an exterior edge.
+            ccw_only: A boolean to note whether the search should be limited
+                to the counter-clockwise direction only. (Default: False).
+
+        Returns:
+            A list of nodes that form a polygon if the cycle exists, else None.
+        """
+        # set up a queue for exploring the graph
+        explored = []
+        queue = [[base_node]]
+        orig_dir = base_node.pt - goal_node.pt  # yields a vector
+        # loop to traverse the graph  with the help of the queue
+        while queue:
+            path = queue.pop(0)
+            node = path[-1]
+            # make sure that the current node has not been visited
+            if node not in explored:
+                prev_dir = node.pt - path[-2].pt if len(path) > 1 else orig_dir
+                # iterate over the neighbors to determine relevant nodes
+                rel_neighbors, rel_angles = [], []
+                for neighbor in node.adj_lst:
+                    if neighbor == goal_node:  # the shortest path was found!
+                        path.append(goal_node)
+                        return path
+                    elif neighbor.exterior:
+                        continue  # don't traverse the graph exterior
+                    edge_dir = neighbor.pt - node.pt
+                    cw_angle = prev_dir.angle_clockwise(edge_dir * -1)
+                    if not (1e-5 < cw_angle < (2 * math.pi) - 1e-5):
+                        continue  # prevent back-tracking along the search
+                    rel_neighbors.append(neighbor)
+                    rel_angles.append(cw_angle)
+                # sort the neighbors by clockwise angle
+                if len(rel_neighbors) > 1:
+                    rel_neighbors = [n for _, n in sorted(zip(rel_angles, rel_neighbors),
+                                                          key=lambda pair: pair[0])]
+                # add the relevant neighbors to the path and the queue
+                if ccw_only:
+                    new_path = list(path)
+                    new_path.append(rel_neighbors[0])
+                    queue.append(new_path)
+                else:  # add all neighbors to the search
+                    for neighbor in rel_neighbors:
+                        new_path = list(path)
+                        new_path.append(neighbor)
+                        queue.append(new_path)
+                explored.append(node)
+        # if we reached the end of the queue, then no path was found
+        return None
+
+    def exterior_cycle(self, cycle_root):
+        """Computes exterior boundary from a given node.
+
+        This method assumes that exterior edges are naked (unidirectional) and
+        interior edges are bidirectional.
+
+        Args:
+            cycle_root: Starting _Node in exterior cycle.
+
+        Returns:
+            List of nodes on exterior if a cycle exists, else None.
+        """
+        # Get the first exterior edge
+        curr_node = cycle_root
+        next_node = PolygonDirectedGraph.next_exterior_node(curr_node)
+        if not next_node:
+            return None
+
+        # loop through the cycle until we get it all or run out of points
+        max_iter = self.node_count + 1  # maximum length a cycle can be
+        ext_cycle = [curr_node]
+        iter_count = 0
+        while next_node.key != cycle_root.key:
+            ext_cycle.append(next_node)
+            next_node = PolygonDirectedGraph.next_exterior_node(next_node)
+            if not next_node:
+                return None  # we have hit a dead end in the cycle
+            iter_count += 1
+            if iter_count > max_iter:
+                break  # we have gotten stuck in a loop
+
+        return ext_cycle
+
+    def exterior_cycles(self):
+        """Get a list of lists where each sub-list is an exterior cycle of Nodes."""
+        exterior_poly_lst = []  # list to store cycles
+        explored_nodes = set()  # set to note explored exterior nodes
+        max_iter = self.node_count + 1  # maximum length a cycle can be
+
+        # loop through all of the nodes of the graph and find cycles
+        for root_node in self.ordered_nodes:
+            # make a note that the current node has been explored
+            explored_nodes.add(root_node.key)  # mark the node as explored
+            # get next exterior adjacent node and check that it's valid
+            next_node = self.next_exterior_node(root_node)  # mark the node as explored
+            is_valid = (next_node is not None) and (next_node.key not in explored_nodes)
+            if not is_valid:
+                continue
+            # make a note that the next node has been explored
+            explored_nodes.add(next_node.key)
+
+            # traverse the loop of points until we get back to start or hit a dead end
+            exterior_poly = [root_node]
+            prev_node = root_node
+            iter_count = 0
+            while next_node.key != root_node.key:
+                exterior_poly.append(next_node)
+                explored_nodes.add(next_node.key)  # mark the node as explored
+                follow_node = self.next_exterior_node_no_backtrack(
+                    next_node, prev_node, explored_nodes)
+                prev_node = next_node  # set as the previous node for the next step
+                next_node = follow_node
+                if next_node is None:
+                    break  # we have hit a dead end in the cycle
+                iter_count += 1
+                if iter_count > max_iter:
+                    print('Extraction of core polygons hit an endless loop.')
+                    break  # we have gotten stuck in a loop
+            exterior_poly_lst.append(exterior_poly)
+
+        # return all of the exterior loops that were found
+        return exterior_poly_lst
+
+    @staticmethod
+    def next_exterior_node_no_backtrack(node, previous_node, explored_nodes):
+        """Get the next exterior node adjacent to the input node.
+
+        This method is similar to the next_exterior_node method but it includes
+        extra checks to handle intersections with 3 or more segments in the
+        graph exterior cycles. In these cases a set of previously explored_nodes
+        is used to ensure that no back-tracking happens over the search of the
+        network, which can lead to infinite looping through the graph. Furthermore,
+        the previous_node is used to select the pathway with the smallest angle
+        difference with the previous direction. This leads the result towards
+        minimal polygons with fewer self-intersecting loops.
+
+        Args:
+            node: A _Node object for which the next node will be returned.
+            previous_node: A _Node object for the node that came before
+                the current one in the loop. This will be used in the event that
+                multiple exterior nodes are found connecting to the input node.
+                In this case, the exterior node with the smallest angle difference
+                with the previous direction will be returned. This leads the
+                result towards minimal polygons and away from self-intersecting
+                exterior loops like a bowtie.
+
+        Returns:
+            Next node that defines exterior edge, or None if all adjacencies are
+            bidirectional.
+        """
+        # loop through the all adjacent nodes and determine if they are exterior
+        next_nodes = []
+        for _next_node in node.adj_lst:
+            if _next_node.exterior:  # user has labeled it as exterior; we're done!
+                return _next_node
+            elif _next_node.exterior is None:  # don't know if it's interior or exterior
+                # if user-assigned attribute isn't defined, check bi-directionality
+                if not PolygonDirectedGraph.is_edge_bidirect(node, _next_node):
+                    next_nodes.append(_next_node)
+
+        # evaluate whether there is one obvious choice for the next node
+        if len(next_nodes) <= 1:
+            return next_nodes[0] if len(next_nodes) == 1 else None
+        next_nodes = [nn for nn in next_nodes if nn.key not in explored_nodes]
+        if len(next_nodes) <= 1:
+            return next_nodes[0] if len(next_nodes) == 1 else None
+
+        # if we have multiple exterior nodes, use the previous node to find the best one
+        prev_dir = previous_node.pt - node.pt  # yields a vector
+        next_angles = []
+        for next_node in next_nodes:
+            edge_dir = next_node.pt - node.pt  # yields a vector
+            next_angles.append(prev_dir.angle(edge_dir * -1))
+        sorted_nodes = [n for _, n in sorted(zip(next_angles, next_nodes),
+                                             key=lambda pair: pair[0])]
+        return sorted_nodes[0]  # return the node making the smallest angle
+
+    @staticmethod
+    def next_exterior_node(node):
+        """Get the next exterior node adjacent to consumed node.
+
+        If there are adjacent nodes that are labeled as exterior, with True or
+        False defining the _Node.exterior property, the first of such nodes in
+        the adjacency list will be returned as the next one. Otherwise, the
+        bi-directionality will be used to determine whether the next node is
+        exterior.
+
+        Args:
+            node: A _Node object for which the next node will be returned.
+
+        Returns:
+            Next node that defines exterior edge, or None if all adjacencies are
+            bidirectional.
+        """
+        # loop through the adjacency and find an exterior node
+        for _next_node in node.adj_lst:
+            if _next_node.exterior:  # user has labeled it as exterior; we're done!
+                return _next_node
+            elif _next_node.exterior is None:  # don't know if it's interior or exterior
+                # if user-assigned attribute isn't defined, check bi-directionality
+                if not PolygonDirectedGraph.is_edge_bidirect(node, _next_node):
+                    return _next_node
+        return None
 
     @staticmethod
     def is_edge_bidirect(node1, node2):
@@ -434,165 +608,117 @@ class PolygonDirectedGraph(object):
         return node1.key in (n.key for n in node2.adj_lst) and \
             node2.key in (n.key for n in node1.adj_lst)
 
-    @staticmethod
-    def next_unidirect_node(node):
-        """Retrieves the first unidirectional point adjacent
-        to consumed point. They define an exterior or naked edge.
+    def __repr__(self):
+        """Represent PolygonDirectedGraph."""
+        s = ''
+        for n in self.ordered_nodes:
+            s += '{}, [{}]\n'.format(
+                n.pt.to_array(),
+                ', '.join([str(_n.pt.to_array()) for _n in n.adj_lst]))
+        return s
 
-        Args:
-            node: _Node
 
-        Returns:
-            Next node that defines unidirectional edge, or None if all
-            adjacencies are bidirectional.
-        """
-        # Check bidirectionality
-        next_node = None
-        for _next_node in node.adj_lst:
-            if not PolygonDirectedGraph.is_edge_bidirect(node, _next_node):
-                next_node = _next_node
-                break
+def skeleton_as_directed_graph(boundary, holes=None, tolerance=1e-5):
+    """Compute the straight skeleton of a shape as a PolygonDirectedGraph.
 
-        return next_node
+    Args:
+        boundary: A ladybug-geometry Polygon2D for the boundary around the shape
+            for which the straight skeleton will be computed.
+        holes: An optional list of ladybug-geometry Polygon2D for the holes within
+            the shape for which a straight skeleton will be computed. If None,
+            it will be assumed that no holes exist in the shape. (Default: None).
+        tolerance: Tolerance for point equivalence. (Default: 1e-5).
 
-    @staticmethod
-    def next_exterior_node(node):
-        """Retrieves the first exterior node adjacent
-        to consumed node. They define an exterior or naked edge.
+    Returns:
+        A PolygonDirectedGraph object that represents the network and boundary
+        of the straight skeleton. All interior connections in the graph are
+        assumed to be bi-directional. The edges (including the boundary
+        and holes) are uni-directional with the outer boundary being counterclockwise
+        and the holes being clockwise. In other words, the fill of the shape is
+        always to the left of each exterior edge. The nodes at the boundary
+        and the holes have the exterior property set to True.
+    """
+    # get the segments representing the straight skeleton
+    skeleton = skeleton_as_edge_list(boundary, holes, tolerance)
+    skeleton, is_intersect_topology = _intersect_skeleton_segments(skeleton, tolerance)
 
-        Args:
-            node: _Node
+    # ensure the boundary and holes are oriented correctly for the graph
+    if boundary.is_clockwise:
+        boundary = boundary.reverse()
+    loops = [boundary.vertices]
+    if holes is not None:
+        for hole in holes:
+            if hole.is_clockwise:
+                loops.append(hole.vertices)
+            else:
+                loops.append(hole.reverse().vertices)
 
-        Returns:
-            Next node that defines exterior edge, or None if all
-            adjacencies are bidirectional.
-        """
+    # make the directed graph and add the nodes for the boundary + holes
+    dg = PolygonDirectedGraph(tol=tolerance)
+    for loop_count, vertices in enumerate(loops):
+        for j in range(len(vertices) - 1):
+            curr_v = vertices[j]
+            next_v = vertices[j + 1]
+            k = dg.add_node(curr_v, [next_v], exterior=True)
+            if j == 0:
+                if loop_count == 0:
+                    dg.outer_root_key = k
+                else:
+                    dg.hole_root_keys.append(k)
+        dg.add_node(vertices[-1], [vertices[0]], exterior=True)  # close loop
 
-        # Check bidirectionality
-        next_node = None
-        for _next_node in node.adj_lst:
+    # add the straight skelton to the graph
+    for seg in skeleton:
+        # add a bidirectional edge to represent skeleton edges
+        dg.add_node(seg.p2, [seg.p1])
+        dg.add_node(seg.p1, [seg.p2], exterior=False)
 
-            if _next_node.exterior is None:
-                # If user-assigned attribute isn't defined, check bidirectionality.
-                if not PolygonDirectedGraph.is_edge_bidirect(node, _next_node):
-                    next_node = _next_node
-                    break
-            elif _next_node.exterior is True:
-                next_node = _next_node
-                break
+    # set the property to track whether the graph is self-intersecting
+    dg.is_intersect_topology = is_intersect_topology
+    return dg
 
-        return next_node
 
-    @staticmethod
-    def exterior_cycle(cycle_root):
-        """Computes exterior boundary from a given node.
+def skeleton_as_cycle_polygons(boundary, holes=None, tolerance=1e-5):
+    """Compute the straight skeleton of a shape as a list of cycle polygons.
 
-        This method assumes that exterior edges are naked (unidirectional) and
-        interior edges are bidirectional.
+    Args:
+        boundary: A ladybug-geometry Polygon2D for the boundary around the shape
+            for which the straight skeleton will be computed.
+        holes: An optional list of ladybug-geometry Polygon2D for the holes within
+            the shape for which a straight skeleton will be computed. If None,
+            it will be assumed that no holes exist in the shape. (Default: None).
+        tolerance: Tolerance for point equivalence. (Default: 1e-5).
 
-        Args:
-            cycle_root: Starting _Node in exterior cycle.
-        Returns:
-            List of nodes on exterior if a cycle exists, else None.
-        """
+    Returns:
+        A list of Polygon2D that represent the straight skeleton of the input shape.
+        There will be one Polygon2D for each edge of the shape (including both
+        the boundary and the holes). Together, the Polygon2Ds will fill the
+        entire input shape. There may be some overlap in between the output
+        polygons if the straight skeleton did not have the correct topology.
+    """
+    # get the straight skeleton as a PolygonDirectedGraph
+    dg = skeleton_as_directed_graph(boundary, holes, tolerance)
 
-        # Get the first exterior edge
-        curr_node = cycle_root
-        next_node = PolygonDirectedGraph.next_exterior_node(curr_node)
-        if not next_node:
-            return None
+    # function to add cycles to the list of polygons to be returned
+    cycle_polys = []
 
-        ext_cycle = [curr_node]
-        while next_node.key != cycle_root.key:
-            ext_cycle.append(next_node)
-            next_node = PolygonDirectedGraph.next_exterior_node(next_node)
-            if not next_node:
-                return None
+    def _add_cycle_polygon(min_cycle):
+        """Add a cycle of Nodes to the list of polygons."""
+        if min_cycle is not None:
+            cycle_poly = Polygon2D([node.pt for node in min_cycle])
+            cycle_polys.append(cycle_poly)
 
-        return ext_cycle
-
-    @staticmethod
-    def _min_ccw_cycle(curr_node, next_node, cycle):
-        """Identify the counter-clockwise adjacent node with the minimum angle.
-
-        Args:
-            curr_node: A node that defines first point of a counter-clockwise
-                polygon edge.
-            next_node: A node connected to the curr_node that defines the second
-                point of a counter-clockwise polygon edge.
-            cycle: Current list of nodes that will form a polygon.
-        Returns:
-            The next connected node that contains the minimum counter-clockwise angle
-            by the edge defined by the curr_node and next_node.
-        """
-        # Get current edge direction vector
-        # N.B point subtraction or addition results in Vector2D
-        edge_dir = next_node.pt - curr_node.pt
-
-        # Initialize values for comparison
-        min_theta = float("inf")
-        min_node = None
-
-        # Identify the node with the smallest ccw angle
-        for adj_node in next_node.adj_lst:
-            # Make sure this node isn't backtracking by checking
-            # new node isn't parent of next_node
-            if adj_node.key == cycle[-2].key:
-                continue
-
-            # Get next edge direction vector
-            next_edge_dir = adj_node.pt - next_node.pt
-            theta = edge_dir.angle_clockwise(next_edge_dir * -1)
-
-            if theta < min_theta:
-                min_theta = theta
-                min_node = adj_node
-
-        return min_node
-
-    @staticmethod
-    def min_ccw_cycle(curr_node, next_node, recurse_limit=3000, print_recurse=False):
-        """Recursively identify most counter-clockwise adjacent node and get closed loop.
-
-        Args:
-            curr_node: The first node, for first edge.
-            next_node: The node next to ref_node that constitutes a polygon edge.
-            recurse_limit: optional parameter to limit the number of while loop cycles.
-                Default: 3000.
-            print_recurse: optional boolean to print cycle loop cycles, for debugging.
-                Default: False.
-
-        Returns:
-            A list of nodes that form a polygon if the cycle exists, else None.
-        """
-        # Set parameters
-        count = 0
-        cycle = [curr_node, next_node]
-        while next_node.key != cycle[0].key:
-            if print_recurse:
-                print('"recursion" cycle: {}'.format(count))
-            # Checks to ensure not trapped in while loop by degenerate skeleton.
-            if recurse_limit and count >= recurse_limit:
-                # Base case 1: recursion limit is hit
-                raise RuntimeError('Error finding the minimum counterclockwise cycle '
-                                   'in this polygon. Recursion limit of {} is '
-                                   'exceeded.'.format(recurse_limit))
-            elif next_node is None:
-                # Base case 2: No node exists in adjacency list
-                raise RuntimeError('Error finding the minimum counterclockwise cycle '
-                                   'in this polygon')
-
-            # Calculate minimum counter-clockwise cycle
-            min_ccw_node = PolygonDirectedGraph._min_ccw_cycle(
-                curr_node, next_node, cycle)
-
-            # Update parameter names
-            curr_node = next_node
-            next_node = min_ccw_node
-            cycle.append(next_node)
-            count += 1
-
-        # Remove final node which is duplicate of first node
-        cycle.pop(0)
-
-        return cycle
+    # convert the edge cycles to Polygon2D
+    exter_cycle = dg.exterior_cycle(dg.outer_root_node)
+    for i, base_node in enumerate(exter_cycle[:-1]):
+        next_node = exter_cycle[i + 1]
+        _add_cycle_polygon(dg.min_cycle(next_node, base_node))
+    _add_cycle_polygon(dg.min_cycle(exter_cycle[0], exter_cycle[-1]))
+    if holes is not None:
+        for hole_root in dg.hole_root_nodes:
+            exter_cycle = dg.exterior_cycle(hole_root)
+            for i, base_node in enumerate(exter_cycle[:-1]):
+                next_node = exter_cycle[i + 1]
+                _add_cycle_polygon(dg.min_cycle(next_node, base_node))
+            _add_cycle_polygon(dg.min_cycle(exter_cycle[0], exter_cycle[-1]))
+    return cycle_polys

--- a/ladybug_geometry_polyskel/polyskel.py
+++ b/ladybug_geometry_polyskel/polyskel.py
@@ -1,147 +1,143 @@
 # coding=utf-8
-"""
-Implementation of the straight skeleton algorithm by Felkel and Obdrzalek[1].
+"""Implementation of the straight skeleton algorithm by Felkel and Obdrzalek[1].
+
+The functions and classes here here are derived directly from the polyskel python
+library by Armin Scipiades (@Bottfy), which is available at:
+https://github.com/Botffy/polyskel
+
 [1] Felkel, Petr and Stepan Obdrzalek. 1998. "Straight Skeleton Implementation." In
 Proceedings of Spring Conference on Computer Graphics, Budmerice, Slovakia. 210 - 218.
 """
-
 from __future__ import division
 
-import logging
 import heapq
 from itertools import tee, islice, cycle, chain
 from collections import namedtuple
 import operator
 
 # Geometry classes
-from ladybug_geometry.geometry2d.pointvector import Point2D
-from ladybug_geometry.geometry2d.line import LineSegment2D
-from ladybug_geometry.geometry2d.ray import Ray2D
-from ladybug_geometry import intersection2d
+from ladybug_geometry.geometry2d import Point2D, Ray2D, LineSegment2D, Polygon2D
+from ladybug_geometry.intersection2d import intersect_line_segment2d, \
+    intersect_line2d
 
 # Polygon sorting classes
 _OriginalEdge = namedtuple('_OriginalEdge', 'edge bisector_left, bisector_right')
 Subtree = namedtuple('Subtree', 'source, height, sinks')
-_SplitEventSubClass = namedtuple('_SplitEvent',
-                                 'distance, intersection_point, vertex, opposite_edge')
-_EdgeEventSubClass = namedtuple('_EdgeEvent',
-                                'distance intersection_point vertex_a vertex_b')
-
-log = logging.getLogger("__name__")
-# logging.basicConfig(filename='dg.log',level=logging.DEBUG)
+_SplitEventSubClass = namedtuple(
+    '_SplitEvent', 'distance, intersection_point, vertex, opposite_edge')
+_EdgeEventSubClass = namedtuple(
+    '_EdgeEvent', 'distance intersection_point vertex_a vertex_b')
 
 
-class _Debug:
-    """The _Debug class stores the bisectors for each edge event."""
+def _window(lst):
+    """Window operator for lists.
 
-    def __init__(self, image):
-        if image is not None:
-            self.im = image[0]
-            self.draw = image[1]
-            self.do = True
-        else:
-            self.do = False
+    Consumes a list of items, and returns a zipped list of the previous,
+    current and next items in the list, accessible by the same index.
 
-    def line(self, *args, **kwargs):
-        if self.do:
-            self.draw.line(*args, **kwargs)
+    Args:
+        lst: list
 
-    def rectangle(self, *args, **kwargs):
-        if self.do:
-            self.draw.rectangle(*args, **kwargs)
-
-    def show(self):
-        if self.do:
-            self.im.show()
+    Returns:
+        Zipped list of previous, current and next items in list.
+    """
+    prevs, items, nexts = tee(lst, 3)
+    prevs = islice(cycle(prevs), len(lst) - 1, None)
+    nexts = islice(cycle(nexts), 1, None)
+    return zip(prevs, items, nexts)
 
 
-_debug = _Debug(None)
+def _cross(a, b):
+    """Get the determinant between two Vector2Ds and/or Point2Ds."""
+    return a.x * b.y - b.x * a.y
 
 
-# Debug set function
-def set_debug(image):
-    global _debug
-    _debug = _Debug(image)
+def _approximately_equals(a, b):
+    """Determine whether two Point2Ds or Vector2Ds are equal within a relative tolerance.
+    """
+    return a == b or (abs(a - b) <= max(abs(a), abs(b)) * 0.001)
+
+
+def _normalize_contour(contour, tol):
+    """Consumes list of x,y coordinate tuples and returns list of Point2Ds.
+
+    Args:
+        contour: list of x,y tuples from contour.
+        tol: Number for point equivalence tolerance.
+
+    Return:
+         list of Point2Ds of contour.
+    """
+    contour = [Point2D(float(x), float(y)) for (x, y) in contour]
+    normed_contour = []
+    for prev, point, next in _window(contour):
+        normed_prev = (point - prev).normalize()
+        normed_next = (next - point).normalize()
+
+        if not point.is_equivalent(next, tol) or \
+                normed_prev.is_equivalent(normed_next, tol):
+            normed_contour.append(point)
+
+    return normed_contour
 
 
 class _SplitEvent(_SplitEventSubClass):
-    """A Split Event is a reflex vertex that splits an Edge Event.
+    """A SplitEvent is a reflex vertex that splits an Edge Event.
 
-    They therefore split the entire polygon and create new adjacencies between the split
-    edge and each of the two edges incident to the reflex vertex
-    (Felkel and Obdrzalek 1998, 1).
+    They therefore split the entire polygon and create new adjacencies between
+    the split edge and each of the two edges incident to the reflex
+    vertex (Felkel and Obdrzalek 1998, 1).
     """
-
     __slots__ = ()
+
+    def __lt__(self, other):
+        return self.distance < other.distance
 
     def __str__(self):
         return "{} Split event @ {} from {} to {}".format(
-            self.distance,
-            self.intersection_point,
-            self.vertex,
-            self.opposite_edge)
+            self.distance, self.intersection_point, self.vertex, self.opposite_edge)
 
 
 class _EdgeEvent(_EdgeEventSubClass):
-    """
-    An Edge Event is an edge extended from a perimeter edge, that shrinks to zero.
+    """An EdgeEvent is an edge extended from a perimeter edge, that shrinks to zero.
 
-    This will make its neighoring edges adjacent (Felkel and Obdrzalek 1998, 2).
+    This will make its neighboring edges adjacent (Felkel and Obdrzalek 1998, 2).
     """
     __slots__ = ()
 
+    def __lt__(self, other):
+        return self.distance < other.distance
+
     def __str__(self):
         return "{} Edge event @ {} between {} and {}".format(
-            self.distance,
-            self.intersection_point,
-            self.vertex_a,
-            self.vertex_b)
+            self.distance, self.intersection_point, self.vertex_a, self.vertex_b)
 
 
 class _LAVertex:
-    """A LAVertex is a vertex in a double connected circular list of active vertices."""
 
-    def __init__(self, point, edge_left, edge_right, direction_vectors=None, tol=1e-10):
+    def __init__(self, point, edge_left, edge_right, direction_vectors=None, tol=1e-5):
+        """A vertex in a double connected circular list of active vertices."""
+        self.tol = tol
         self.point = point
         self.edge_left = edge_left
         self.edge_right = edge_right
         self.prev = None
         self.next = None
         self.lav = None
-        self.tol = tol
-        self.id = None
-        # this should be handled better. Maybe membership in lav implies validity?
+        # TODO this might be handled better. Maybe membership in lav implies validity?
         self._valid = True
+
         creator_vectors = (edge_left.v.normalize() * -1, edge_right.v.normalize())
         if direction_vectors is None:
             direction_vectors = creator_vectors
-        # The determinant of two 2d vectors equals the sign of their cross product
-        # If second vector is to left, then sign of det is pos, else neg
-        # So if cw polygon, convex angle will be neg (since second vector to right)
-        # In this case, since we flip first vector, concave will be neg
-        self._is_reflex = direction_vectors[0].determinant(direction_vectors[1]) < 0.0
+
+        self._is_reflex = (_cross(*direction_vectors)) < 0
         self._bisector = Ray2D(
-            self.point,
-            operator.add(*creator_vectors) * (-1 if self.is_reflex else 1)
-        )
-        log.info("Created vertex %s", self.__repr__())
-        _debug.line(
-            (self.bisector.p.x, self.bisector.p.y,
-             self.bisector.p.x + self.bisector.v.x * 100,
-             self.bisector.p.y + self.bisector.v.y * 100),
-            fill="blue")
+            self.point, operator.add(*creator_vectors) * (-1 if self.is_reflex else 1))
 
     @property
     def bisector(self):
         return self._bisector
-
-    def __eq__(self, other):
-        """Equality of this _LAvertex with another."""
-        return self.point.is_equivalent(other.point, self.tol) and \
-            self.edge_left.is_equivalent(other.edge_left, self.tol) and \
-            self.edge_right.is_equivalent(other.edge_right, self.tol) and \
-            self.next.point.is_equivalent(other.next.point, self.tol) and \
-            self.prev.point.is_equivalent(other.prev.point, self.tol)
 
     @property
     def is_reflex(self):
@@ -152,33 +148,19 @@ class _LAVertex:
         return self.lav._slav._original_edges
 
     def next_event(self):
-        """ Computes the event (change to edge) associated with each polygon vertex.
-
-        Reflex vertices can result in split or edge events, while non-reflex vertices
-        will result in only edge events.
-
-        Returns:
-            EdgeEvent associated with self.
-        """
         events = []
         if self.is_reflex:
-            # a reflex vertex may generate a split event
-            # split events happen when a vertex hits an opposite edge,
-            # splitting the polygon in two.
-            log.debug("looking for split candidates for vertex %s", self)
+            # A reflex vertex may generate a split event.
+            # Split events happen when a vertex hits an opposite edge,
+            # thereby splitting the polygon in two.
             for edge in self.original_edges:
-                cond_1 = edge.edge.is_equivalent(self.edge_left, self.tol)
-                if cond_1 or edge.edge.is_equivalent(self.edge_right, self.tol):
+                if edge.edge == self.edge_left or edge.edge == self.edge_right:
                     continue
 
-                log.debug('\tconsidering EDGE %s', edge)
-
-                # A potential b is at the intersection of between our own bisector and
+                # A potential b is at the intersection between our own bisector and
                 # the bisector of the angle between the tested edge and any one of our
                 # own edges.
-
-                # We choose the 'less parallel' edge (in order to exclude a
-                # potentially parallel edge)
+                # We choose 'less parallel' edge (to exclude a potentially parallel edge)
 
                 # Make normalized copies of vectors
                 norm_edge_left_v = self.edge_left.v.normalize()
@@ -189,17 +171,13 @@ class _LAVertex:
                 leftdot = abs(norm_edge_left_v.dot(norm_edge_v))
                 rightdot = abs(norm_edge_right_v.dot(norm_edge_v))
                 selfedge = self.edge_left if leftdot < rightdot else self.edge_right
-                # otheredge = self.edge_left if leftdot > rightdot else self.edge_right
 
                 # Make copies of edges and compute intersection
-                self_edge_copy = LineSegment2D(selfedge.p, selfedge.v)
-                edge_edge_copy = LineSegment2D(edge.edge.p, edge.edge.v)
-                # Ray line intersection
-                i = intersection2d.intersect_line2d_infinite(
-                    edge_edge_copy,
-                    self_edge_copy)
+                self_copy = LineSegment2D(selfedge.p, selfedge.v)
+                edge_copy = LineSegment2D(edge.edge.p, edge.edge.v)
+                i = intersect_line_segment2d(edge_copy, self_copy)
 
-                if (i is not None) and (not i.is_equivalent(self.point, self.tol)):
+                if i is not None and not _approximately_equals(i, self.point):
                     # locate candidate b
                     linvec = (self.point - i).normalize()
                     edvec = edge.edge.v.normalize()
@@ -207,78 +185,56 @@ class _LAVertex:
                         edvec = -edvec
 
                     bisecvec = edvec + linvec
-                    if abs(bisecvec.magnitude) < self.tol:
+                    if abs(bisecvec) == 0:
                         continue
                     bisector = LineSegment2D(i, bisecvec)
-                    b = intersection2d.intersect_line2d(self.bisector, bisector)
+                    b = intersect_line2d(self.bisector, bisector)
+
                     if b is None:
                         continue
 
-                    # check eligibility of b
-                    # a valid b should lie within the area limited by the edge and the
-                    # bisectors of its two vertices:
+                    # Check eligibility of b.
+                    # A valid b should lie within the area limited by the edge
+                    # and the bisectors of its two vertices.
                     _left_bisector_norm = edge.bisector_left.v.normalize()
-                    _left_to_b_norm = (b - edge.bisector_left.p).normalize()
-                    xleft = _left_bisector_norm.determinant(_left_to_b_norm) > 0
+                    _left_b_norm = (b - edge.bisector_left.p).normalize()
+                    xleft = _left_bisector_norm.determinant(_left_b_norm) > -self.tol
 
                     _right_bisector_norm = edge.bisector_right.v.normalize()
-                    _right_to_b_norm = (b - edge.bisector_right.p).normalize()
-                    xright = _right_bisector_norm.determinant(_right_to_b_norm) < 0
+                    _right_b_norm = (b - edge.bisector_right.p).normalize()
+                    xright = _right_bisector_norm.determinant(_right_b_norm) < self.tol
 
                     _edge_edge_norm = edge.edge.v.normalize()
                     _b_to_edge_norm = (b - edge.edge.p).normalize()
-                    xedge = _edge_edge_norm.determinant(_b_to_edge_norm) < 0
+                    xedge = _edge_edge_norm.determinant(_b_to_edge_norm) < self.tol
 
                     if not (xleft and xright and xedge):
-                        log.debug(
-                            '\t\tDiscarded candidate %s (%s-%s-%s)',
-                            b, xleft, xright, xedge)
-                        continue
-
-                    log.debug('\t\tFound valid candidate %s', b)
-                    _dist_line_to_b = LineSegment2D(
-                        edge.edge.p,
-                        edge.edge.v).distance_to_point(b)
-                    if _dist_line_to_b < self.tol:
-                        _dist_line_to_b = 0.0
-                    _new_split_event = _SplitEvent(_dist_line_to_b, b, self, edge.edge)
+                        continue  # discarded candidate
+                    # found valid candidate
+                    _d2b = LineSegment2D(edge.edge.p, edge.edge.v).distance_to_point(b)
+                    _new_split_event = _SplitEvent(_d2b, b, self, edge.edge)
                     events.append(_new_split_event)
 
-        # Intersect line2d with line2d (does not assume lines are infinite)
-        i_prev = intersection2d.intersect_line2d_infinite(
-            self.prev.bisector, self.bisector)
-        i_next = intersection2d.intersect_line2d_infinite(
-            self.next.bisector, self.bisector)
-        # Make EdgeEvent and append to events
-        if i_prev is not None:
-            dist_to_i_prev = LineSegment2D(
-                self.edge_left.p.duplicate(),
-                self.edge_left.v.duplicate()).distance_to_point(i_prev)
-            if dist_to_i_prev < self.tol:
-                dist_to_i_prev = 0.0
-            events.append(_EdgeEvent(dist_to_i_prev, i_prev, self.prev, self))
+        i_prev = self.bisector.intersect_line_ray(self.prev.bisector)
+        i_next = self.bisector.intersect_line_ray(self.next.bisector)
 
+        if i_prev is not None:
+            left_seg = LineSegment2D(self.edge_left.p, self.edge_left.v)
+            dist_to_i_prev = left_seg.distance_to_point(i_prev)
+            events.append(_EdgeEvent(dist_to_i_prev, i_prev, self.prev, self))
         if i_next is not None:
-            dist_to_i_next = LineSegment2D(
-                self.edge_right.p.duplicate(),
-                self.edge_right.v.duplicate()).distance_to_point(i_next)
-            if dist_to_i_next < self.tol:
-                dist_to_i_next = 0.0
+            right_seg = LineSegment2D(self.edge_right.p, self.edge_right.v)
+            dist_to_i_next = right_seg.distance_to_point(i_next)
             events.append(_EdgeEvent(dist_to_i_next, i_next, self, self.next))
 
         if not events:
             return None
 
-        ev = min(events,
-                 key=lambda event:
+        ev = min(events, key=lambda event:
                  self.point.distance_to_point(event.intersection_point))
-
-        log.info('Generated new event for %s: %s', self, ev)
         return ev
 
     def invalidate(self):
-        """Mutates invalidate attribute of self.
-        """
         if self.lav is not None:
             self.lav.invalidate(self)
         else:
@@ -289,43 +245,32 @@ class _LAVertex:
         return self._valid
 
     def __str__(self):
-        return 'Vertex ({:.2f};{:.2f})'.format(self.point.x, self.point.y)
-
-    def __lt__(self, other):
-        if isinstance(other, _LAVertex):
-            return self.point.x < other.point.x
+        return "Vertex ({:.2f};{:.2f})".format(self.point.x, self.point.y)
 
     def __repr__(self):
         return 'Vertex ({}) ({:.2f};{:.2f}), bisector {}, edges {} {}'.format(
             'reflex' if self.is_reflex else 'convex',
-            self.point.x,
-            self.point.y,
-            self.bisector,
-            self.edge_left,
-            self.edge_right)
+            self.point.x, self.point.y, self.bisector,
+            self.edge_left, self.edge_right)
 
 
 class _SLAV:
-    """ A SLAV is a set of circular lists of active vertices.
 
-    It stores a loop of vertices for the outer boundary, and for all holes and
-    sub-polygons created during the straight skeleton computation
-    (Felkel and Obdrzalek 1998, 2).
-    """
+    def __init__(self, polygon, tol=1e-5):
+        """ A set of circular lists of active vertices.
 
-    def __init__(self, polygon, holes, tol):
+        It stores a loop of vertices for the polygon created during the straight
+        skeleton computation (Felkel and Obdrzalek 1998).
+        """
         self.tol = tol
         contours = [_normalize_contour(polygon, tol)]
-        contours.extend([_normalize_contour(hole, tol) for hole in holes])
-
         self._lavs = [_LAV.from_polygon(contour, self) for contour in contours]
 
-        # Store original polygon edges for calculating split events
+        # store original polygon edges for calculating split events
         self._original_edges = [
             _OriginalEdge(
-                LineSegment2D.from_end_points(vertex.prev.point, vertex.point),
-                vertex.prev.bisector,
-                vertex.bisector
+                LineSegment2D(vertex.prev.point, vertex.point),
+                vertex.prev.bisector, vertex.bisector
             ) for vertex in chain.from_iterable(self._lavs)
         ]
 
@@ -355,25 +300,17 @@ class _SLAV:
         events = []
 
         lav = event.vertex_a.lav
-        # Triangle, one sink point
-        if event.vertex_a.prev.point.is_equivalent(event.vertex_b.next.point, self.tol):
-            log.info('%.2f Peak event at intersection %s from <%s,%s,%s> in %s',
-                     event.distance, event.intersection_point, event.vertex_a,
-                     event.vertex_b, event.vertex_a.prev, lav)
+        # triangle; one sink point
+        if event.vertex_a.prev == event.vertex_b.next:
             self._lavs.remove(lav)
-            lst_lav = list(lav)
-            for vi, vertex in enumerate(lst_lav):
+            for vertex in list(lav):
                 sinks.append(vertex.point)
                 vertex.invalidate()
         else:
-            log.info('%.2f Edge event at intersection %s from <%s,%s> in %s',
-                     event.distance, event.intersection_point, event.vertex_a,
-                     event.vertex_b, lav)
-            new_vertex = lav.unify(event.vertex_a,
-                                   event.vertex_b, event.intersection_point)
+            new_vertex = lav.unify(event.vertex_a, event.vertex_b,
+                                   event.intersection_point)
             if lav.head in (event.vertex_a, event.vertex_b):
                 lav.head = new_vertex
-
             sinks.extend((event.vertex_a.point, event.vertex_b.point))
             next_event = new_vertex.next_event()
             if next_event is not None:
@@ -394,46 +331,27 @@ class _SLAV:
             Subtree namedTuple
         """
         lav = event.vertex.lav
-        log.info(
-            '%.2f Split event at intersection %s from vertex %s, for edge %s in %s',
-            event.distance,
-            event.intersection_point,
-            event.vertex,
-            event.opposite_edge,
-            lav)
-
         sinks = [event.vertex.point]
         vertices = []
         x = None  # right vertex
         y = None  # left vertex
         norm = event.opposite_edge.v.normalize()
         for v in chain.from_iterable(self._lavs):
-            log.debug('%s in %s', v, v.lav)
-            equal_to_edge_left_p = event.opposite_edge.p.is_equivalent(
-                v.edge_left.p, self.tol)
-            equal_to_edge_right_p = event.opposite_edge.p.is_equivalent(
-                v.edge_right.p, self.tol)
-
-            _pnorm = Point2D(norm.x, norm.y)
-            if _pnorm.is_equivalent(v.edge_left.v.normalize(), self.tol) \
-                    and equal_to_edge_left_p:
+            if norm == v.edge_left.v.normalize() and \
+                    event.opposite_edge.p == v.edge_left.p:
                 x = v
                 y = x.prev
-            elif _pnorm.is_equivalent(v.edge_right.v.normalize(), self.tol) \
-                    and equal_to_edge_right_p:
+            elif norm == v.edge_right.v.normalize() and \
+                    event.opposite_edge.p == v.edge_right.p:
                 y = v
                 x = y.next
 
             if x:
                 xleft = y.bisector.v.normalize().determinant(
-                    (event.intersection_point - y.point).normalize()) >= 0
+                    (event.intersection_point - y.point).normalize()) >= -self.tol
 
                 xright = x.bisector.v.normalize().determinant(
-                    (event.intersection_point - x.point).normalize()) <= 0
-
-                log.debug(
-                    'Vertex %s holds edge as %s edge (%s, %s)', v,
-                    ('left' if x == v else 'right'), xleft, xright)
+                    (event.intersection_point - x.point).normalize()) <= self.tol
 
                 if xleft and xright:
                     break
@@ -442,24 +360,12 @@ class _SLAV:
                     y = None
 
         if x is None:
-            log.info(
-                'Failed split event %s (equivalent edge event is expected to follow)',
-                event
-            )
             return (None, [])
 
-        v1 = _LAVertex(
-            event.intersection_point,
-            event.vertex.edge_left,
-            event.opposite_edge,
-            tol=self.tol
-        )
-        v2 = _LAVertex(
-            event.intersection_point,
-            event.opposite_edge,
-            event.vertex.edge_right,
-            tol=self.tol
-        )
+        v1 = _LAVertex(event.intersection_point, event.vertex.edge_left,
+                       event.opposite_edge, tol=self.tol)
+        v2 = _LAVertex(event.intersection_point, event.opposite_edge,
+                       event.vertex.edge_right, tol=self.tol)
 
         v1.prev = event.vertex.prev
         v1.next = x
@@ -481,15 +387,10 @@ class _SLAV:
             new_lavs = [_LAV.from_chain(v1, self), _LAV.from_chain(v2, self)]
 
         for lv in new_lavs:
-            log.debug(lv)
             if len(lv) > 2:
                 self._lavs.append(lv)
                 vertices.append(lv.head)
             else:
-                log.info(
-                    'LAV %s has collapsed into the line %s--%s',
-                    lv, lv.head.point, lv.head.next.point
-                )
                 sinks.append(lv.head.next.point)
                 for v in list(lv):
                     v.invalidate()
@@ -505,17 +406,16 @@ class _SLAV:
 
 
 class _LAV:
-    """A single circular list of active vertices.
-
-    Stored in a SLAV (Felkel and Obdrzalek 1998, 2).
-    """
 
     def __init__(self, slav):
+        """A single circular list of active vertices.
+
+        Stored in a SLAV (Felkel and Obdrzalek 1998, 2).
+        """
         self.head = None
         self._slav = slav
         self._len = 0
         self.tol = slav.tol
-        log.debug('Created LAV %s', self)
 
     @classmethod
     def from_polygon(cls, polygon, slav):
@@ -524,7 +424,6 @@ class _LAV:
         Args:
             polygon: list of points (tuple of x,y coordinates).
             slav: SLAV (a set of circular lists of active vertices).
-            tol: tolerance for point equality.
 
         Returns:
             LAV (single circular list of active vertices).
@@ -573,32 +472,28 @@ class _LAV:
         Args:
             vertex: _LAVertex to be invalidated.
         """
-        assert vertex.lav is self, 'Tried to invalidate a vertex thats not mine'
-        log.debug('Invalidating %s', vertex)
+        assert vertex.lav is self, 'Tried to invalidate a vertex that is not mine'
         vertex._valid = False
         if self.head == vertex:
             self.head = self.head.next
         vertex.lav = None
 
     def unify(self, vertex_a, vertex_b, point):
-        """Generate a new _LAVertex from input Point2D and resolve adjacency to old edges
+        """Generate new _LAVertex from input Point2D and resolve adjacency to old edges.
 
         Args:
-            vertex_a = _LAVertex
-            vertex_b = _LAVertex
-            point = intersection point from angle bisectors from vertex_a
-                and vertex_b as a Point2D.
+            vertex_a: _LAVertex
+            vertex_b: _LAVertex
+            point: Intersection point from angle bisectors from vertex_a and
+                vertex_b as a Point2D.
+
         Returns:
             _LAVertex of intersection point.
         """
-        normed_b_bisector = vertex_b.bisector.v.normalize()
-        normed_a_bisector = vertex_a.bisector.v.normalize()
         replacement = _LAVertex(
-            point,
-            vertex_a.edge_left,
-            vertex_b.edge_right,
-            (normed_b_bisector, normed_a_bisector),
-            tol=vertex_a.tol,
+            point, vertex_a.edge_left, vertex_b.edge_right,
+            (vertex_b.bisector.v.normalize(), vertex_a.bisector.v.normalize()),
+            tol=vertex_a.tol
         )
         replacement.lav = self
 
@@ -617,10 +512,10 @@ class _LAV:
         return replacement
 
     def __str__(self):
-        return 'LAV {}'.format(id(self))
+        return "LAV {}".format(id(self))
 
     def __repr__(self):
-        return '{} = {}'.format(str(self), [vertex for vertex in self])
+        return "{} = {}".format(str(self), [vertex for vertex in self])
 
     def __len__(self):
         return self._len
@@ -629,15 +524,11 @@ class _LAV:
         cur = self.head
         while True:
             yield cur
-            try:
-                cur = cur.next
-                if cur == self.head:
-                    raise StopIteration
-            except StopIteration:
+            cur = cur.next
+            if cur == self.head:
                 return
 
     def _show(self):
-        """ Iterates through _LAV linked list and prints _LAVertex."""
         cur = self.head
         while True:
             print(cur.__repr__())
@@ -647,11 +538,9 @@ class _LAV:
 
 
 class _EventQueue:
-    """
-    An EventQueue is a priority queue that stores vertices of the polygon.
-    """
 
     def __init__(self):
+        """A priority queue that stores vertices of the polygon."""
         self.__data = []
 
     def put(self, item):
@@ -676,62 +565,64 @@ class _EventQueue:
             print(item)
 
 
-# Skeleton Code
-def _window(lst):
-    """
-    Window operator for lists.
+def _merge_sources(skeleton):
+    """Merge the sources of a straight skeleton.
 
-    Consume a list of items, and returns a zipped list of the previous, current and next
-    items in the list, accessible by the same index.
+    In highly symmetrical shapes with reflex vertices, multiple sources may share
+    the same  location. This function merges those sources.
+    """
+    sources = {}
+    to_remove = []
+    for i, p in enumerate(skeleton):
+        source = tuple(i for i in p.source)
+        if source in sources:
+            source_index = sources[source]
+            # source exists, merge sinks
+            for sink in p.sinks:
+                if sink not in skeleton[source_index].sinks:
+                    skeleton[source_index].sinks.append(sink)
+            to_remove.append(i)
+        else:
+            sources[source] = i
+    for i in reversed(to_remove):
+        skeleton.pop(i)
+
+
+def _clean_sinks(skeleton, tol=1e-5):
+    """Remove cases where the source and sink point are the same.
+
+    This can occur as an unintended effect of merging sources.
+    """
+    clean_subtrees = []
+    for s_tree in skeleton:
+        source, clean_sinks, is_invalid = s_tree.source, [], False
+        for sink in s_tree.sinks:
+            if source.is_equivalent(sink, tol):
+                is_invalid = True
+            else:
+                clean_sinks.append(sink)
+        if is_invalid:  # create a new Subtree
+            clean_subtrees.append(Subtree(source, s_tree.height, clean_sinks))
+        else:
+            clean_subtrees.append(s_tree)
+    return clean_subtrees
+
+
+def _skeletonize(polygon, tol=1e-5):
+    """Compute the straight skeleton of a Polygon.
 
     Args:
-        lst: list
+        polygon: A list of 2D vertices in clockwise order (when viewed from
+            above the XY plane). For example, a square can be represented with
+            the following: [[0,1], [1,1], [0,0], [1,0]]
+        tol: Tolerance for point equivalence. (Default: 1e-5).
 
     Returns:
-        Zipped list of previous, current and next items in list.
+        The straight skeleton as a list of "subtrees", which are in the form of
+        (source, height, sinks). Source is the highest points, height is its
+        height, and sinks are the point connected to the source.
     """
-    prevs, items, nexts = tee(lst, 3)
-    prevs = islice(cycle(prevs), len(lst) - 1, None)
-    nexts = islice(cycle(nexts), 1, None)
-    return zip(prevs, items, nexts)
-
-
-def _normalize_contour(contour, tol):
-    """
-    Consumes list of x,y coordinate tuples and returns list of Point2Ds.
-
-    Args:
-        contour: list of x,y tuples from contour.
-        tol: Number for point equivalence tolerance.
-    Return:
-         list of Point2Ds of contour.
-    """
-    contour = [Point2D(float(x), float(y)) for (x, y) in contour]
-    normed_contour = []
-    for prev, point, next in _window(contour):
-        normed_prev = (point - prev).normalize()
-        normed_next = (next - point).normalize()
-
-        if not point.is_equivalent(next, tol) or \
-                normed_prev.is_equivalent(normed_next, tol):
-            normed_contour.append(point)
-
-    return normed_contour
-
-
-def _skeletonize(slav):
-    """
-    Compute polygon straight skeleton from a Set of List of Active vertex (SLAV).
-
-    The SLAV will represent the polygon as a double linked list of vertices in
-    counter-clockwise order. Holes is a similar list with the vertices of which
-    should be in clockwise order.
-
-    Args:
-        slav: SLAV object.
-    Returns:
-        List of subtrees.
-    """
+    slav = _SLAV(polygon, tol=tol)
     output = []
     prioque = _EventQueue()
 
@@ -745,82 +636,185 @@ def _skeletonize(slav):
     # from the new intersection via the next_event method. Thus, this while loop
     # iteratively adds new events without recursion.
     while not (prioque.empty() or slav.empty()):
-        log.debug('SLAV is %s', [repr(lav) for lav in slav])
         i = prioque.get()  # vertex a, b is self or next vertex
-
         # Handle edge or split events.
         # arc: subtree(event.intersection_point, event.distance, sinks)
         # events: updated events with new vertex
         if isinstance(i, _EdgeEvent):
             if not i.vertex_a.is_valid or not i.vertex_b.is_valid:
-                log.info('%.2f Discarded outdated edge event %s', i.distance, i)
                 continue
             (arc, events) = slav.handle_edge_event(i)
         elif isinstance(i, _SplitEvent):
             if not i.vertex.is_valid:
-                log.info('%.2f Discarded outdated split event %s', i.distance, i)
                 continue
             (arc, events) = slav.handle_split_event(i)
         prioque.put_all(events)
+
         # As we traverse priorque, output list of "subtrees", which are in the form
         # of (source, height, sinks) where source is the highest points, height is
         # its distance to an edge, and sinks are the point connected to the source.
         if arc is not None:
             output.append(arc)
-            for sink in arc.sinks:
-                _debug.line((arc.source.x, arc.source.y, sink.x, sink.y), fill='red')
-            _debug.show()
-
+    # merge the sources and clean the result
+    _merge_sources(output)
+    output = _clean_sinks(output, tol=1e-5)
     return output
 
 
-def skeleton_as_subtree_list(polygon, holes=None, tol=1e-10):
-    """Compute polygon straight skeleton as a list of subtree source and sink points.
+def _intersect_skeleton_segments(skeleton, tolerance=1e-5):
+    """Intersect all of the LineSegment2D of the skeleton and split them.
 
     Args:
-        polygon: nested list of endpoint coordinates in counter-clockwise order.
-            Example square: [[0,0], [1,0], [1,1], [0,1]]
-        holes: list of polygons representing holes in clockwise order.
-            Example hole: [[.25,.75], [.75,.75], [.75,.25], [.25,.25]]
-        tol: Tolerance for point equivalence. (Default: 1e-10).
+        skeleton: A list of ladybug-geometry LineSegment2D for the segments
+            of the straight skeleton.
+        tolerance: The tolerance at which the intersection will be computed.
 
     Returns:
-        List of subtrees.
+        A tuple with two items.
+
+        * split_skeleton -- A list of LineSegment2D objects for the skeleton
+            split through self-intersection.
+
+        * is_intersect_topology -- A boolean value for whether the topology of the
+            input skeleton is self-intersecting. This value is True whenever
+            there are segments that were split as part of this operation.
     """
+    skel_tol = tolerance / 100  # use a finer tolerance for actual skeleton
+    # compute all of the intersection points across the skeleton
+    intersect_pts = [[] for _ in skeleton]
+    for i, seg in enumerate(skeleton):
+        try:
+            for other_seg in skeleton[:i] + skeleton[i + 1:]:
+                int_pt = intersect_line_segment2d(seg, other_seg)
+                if int_pt is None or int_pt.is_equivalent(seg.p1, skel_tol) or \
+                        int_pt.is_equivalent(seg.p2, skel_tol):
+                    continue
+                # we have found an intersection point where segments should be split
+                intersect_pts[i].append(int_pt)
+        except IndexError:
+            pass  # we have reached the end of the list
 
-    # Reverse order to ensure cw order for input
-    holes = [] if holes is None else [reversed(hole) for hole in holes]
-    slav = _SLAV(reversed(polygon), holes, tol)
+    # loop through the segments and split them at the intersection points
+    split_skeleton, is_intersect_topology = [], False
+    for seg, split_pts in zip(skeleton, intersect_pts):
+        if len(split_pts) == 0:
+            split_skeleton.append(seg)
+        elif len(split_pts) == 1:  # split the segment in two
+            is_intersect_topology = True
+            int_pt = split_pts[0]
+            split_skeleton.append(LineSegment2D.from_end_points(seg.p1, int_pt))
+            split_skeleton.append(LineSegment2D.from_end_points(int_pt, seg.p2))
+        else:  # sort the points along the segment to split it
+            is_intersect_topology = True
+            pt_dists = [seg.p1.distance_to_point(ipt) for ipt in split_pts]
+            sort_obj = sorted(zip(pt_dists, split_pts), key=lambda pair: pair[0])
+            sort_pts = [x for _, x in sort_obj]
+            sort_pts.append(seg.p2)
+            pr_pt = seg.p1
+            for s_pt in sort_pts:
+                if not pr_pt.is_equivalent(s_pt, skel_tol):
+                    split_skeleton.append(LineSegment2D.from_end_points(pr_pt, s_pt))
+                pr_pt = s_pt
 
-    subtree_list = _skeletonize(slav)
+    return split_skeleton, is_intersect_topology
+
+
+def skeleton_as_subtree_list(boundary, holes=None, tolerance=1e-5):
+    """Get a straight skeleton as a list of Subtree source and sink points.
+
+    Args:
+        boundary: A ladybug-geometry Polygon2D for the boundary around the shape
+            for which the straight skeleton will be computed.
+        holes: An optional list of ladybug-geometry Polygon2D for the holes within
+            the shape for which a straight skeleton will be computed. If None,
+            it will be assumed that no holes exist in the shape. (Default: None).
+        tolerance: Tolerance for point equivalence. (Default: 1e-5).
+
+    Returns:
+        A list of Subtree objects that represent the straight skeleton.
+    """
+    # merge the holes into the boundary if they are specified
+    if holes is not None and len(holes) != 0:
+        bound_pts = list(boundary.vertices)
+        hole_pts = [list(h.vertices) for h in holes]
+        boundary = Polygon2D.from_shape_with_holes(bound_pts, hole_pts)
+
+    # pre-process the boundary to be sure it is in the right order
+    boundary = boundary.remove_duplicate_vertices(tolerance)
+    if not boundary.is_clockwise:
+        boundary = boundary.reverse()
+
+    # skeletonize the objects
+    skel_tol = tolerance / 100  # use a finer tolerance for actual skeleton
+    subtree_list = _skeletonize(boundary.to_array(), skel_tol)
+
+    # if holes were merged into the boundary, try to clean up the merge seams
+    if holes is not None and len(holes) != 0:
+        # gather the seams along which holes were merged
+        all_segs, seam_segs = boundary.segments, []
+        for i, seg in enumerate(all_segs):
+            try:
+                for o_seg in all_segs[i + 1:]:
+                    if seg.p1.is_equivalent(o_seg.p2, tolerance) and \
+                            seg.p2.is_equivalent(o_seg.p1, tolerance):
+                        seam_segs.append(seg)
+                        break
+            except IndexError:
+                pass  # we have reached the end of the list
+        # replace the subtrees along the seam with the seam itself
+        for seam in seam_segs:
+            s_p1, s_p2 = seam.p1, seam.p2
+            new_subtrees, connecting_pts, new_height = [], [], 0
+            for sub_tree in subtree_list:
+                sink_pts = sub_tree.sinks
+                replace_sub = False
+                if len(sink_pts) == 2:
+                    if s_p1.is_equivalent(sink_pts[0], tolerance) or \
+                            s_p1.is_equivalent(sink_pts[1], tolerance):
+                        if s_p2.is_equivalent(sink_pts[0], tolerance) or \
+                                s_p2.is_equivalent(sink_pts[1], tolerance):
+                            new_height = sub_tree.height
+                            replace_sub = True
+                            connecting_pts.append(sub_tree.source)
+                if not replace_sub:
+                    new_subtrees.append(sub_tree)
+            subtree_list = new_subtrees
+            seam_sub = Subtree(seam.midpoint, new_height, connecting_pts + [s_p1, s_p2])
+            subtree_list.append(seam_sub)
 
     return subtree_list
 
 
-def skeleton_as_edge_list(polygon, holes=None, tol=1e-10):
-    """Compute the straight skeleton of a polygon and returns skeleton as list of edges.
+def skeleton_as_edge_list(boundary, holes=None, tolerance=1e-5, intersect=False):
+    """Get a straight skeleton as list of LineSegment2D.
 
     Args:
-        polygon: list of list of point coordinates in counter-clockwise order.
-            Example square: [[0,0], [1,0], [1,1], [0,1]]
-        holes: list of polygons representing holes in clockwise order.
-            Example hole: [[.25,.75], [.75,.75], [.75,.25], [.25,.25]].
-        tol: Tolerance for point equivalence. (Default: 1e-10).
+        boundary: A ladybug-geometry Polygon2D for the boundary around the shape
+            for which the straight skeleton will be computed.
+        holes: An optional list of ladybug-geometry Polygon2D for the holes within
+            the shape for which a straight skeleton will be computed. If None,
+            it will be assumed that no holes exist in the shape. (Default: None).
+        tolerance: Tolerance for point equivalence. (Default: 1e-5).
+        intersect: A boolean to note whether the segments of the skeleton should
+            be intersected with one another before being returned. This can
+            help make the skeleton more usable in the event that its topology
+            is not correct. (Default: False).
 
     Returns:
-        list of lines as coordinate tuples.
+        A list of LineSegment2D that represent the straight skeleton.
     """
-    edge_lst = []
+    # get the Subtree representation of the straight skeleton
+    subtree_list = skeleton_as_subtree_list(boundary, holes, tolerance)
 
-    # Reverse order to ensure cw order for input
-    holes = [] if holes is None else [hole[::-1] for hole in holes]
-    slav = _SLAV(polygon[::-1], holes, tol)
-    subtree_list = _skeletonize(slav)
-
+    # extract the LineSegment2D from the Subtree representation
+    skeleton = []
     for subtree in subtree_list:
         source_pt = subtree.source
         for sink_pt in subtree.sinks:
-            edge_arr = ((source_pt.x, source_pt.y), (sink_pt.x, sink_pt.y))
-            edge_lst.append(edge_arr)
+            edge_seg = LineSegment2D.from_end_points(
+                Point2D(source_pt.x, source_pt.y), Point2D(sink_pt.x, sink_pt.y))
+            skeleton.append(edge_seg)
 
-    return edge_lst
+    if intersect:  # intersect skeleton segments to split them
+        skeleton, _ = _intersect_skeleton_segments(skeleton, tolerance)
+    return skeleton

--- a/ladybug_geometry_polyskel/polysplit.py
+++ b/ladybug_geometry_polyskel/polysplit.py
@@ -1,278 +1,152 @@
 # coding=utf-8
-"""Functions for splitting a polygon into subpolygons based on skeleton topology."""
+"""Functions for splitting a polygon into sub-polygons based on skeleton topology."""
 from __future__ import division
 
-from ladybug_geometry.geometry2d.polygon import Polygon2D
-from ladybug_geometry.geometry2d.line import LineSegment2D
-from ladybug_geometry.geometry3d.pointvector import Vector3D
-from ladybug_geometry.intersection2d import does_intersection_exist_line2d
+from ladybug_geometry.geometry2d import LineSegment2D, Polygon2D
+from ladybug_geometry.geometry3d import Vector3D, Face3D
 
-from ladybug_geometry_polyskel import polyskel
-from ladybug_geometry_polyskel.polygraph import PolygonDirectedGraph, _vector2hash
-
-POLYSKELETON_ERROR_MSG = \
-    'The straight skeleton topology calculated for this geometry is incorrect.'
+from .polygraph import PolygonDirectedGraph, \
+    skeleton_as_directed_graph
 
 
-def skeleton_subpolygons(polygon, holes=None, tol=1e-8, recurse_limit=3000,
-                         print_recurse=False):
-    """Compute the polygon straight skeleton as a list of polygon point arrays.
+def perimeter_core_subfaces(face, distance, tolerance=1e-5):
+    """Compute perimeter and core Face3Ds using the straight skeleton of an input Face3D.
 
     Args:
-        polygon: list of Polygon2D objects.
-        holes: list of Polygon2D objects representing holes in cw order. (Default: None).
-        tol: Tolerance for point equivalence. (Default: 1e-10).
-        recurse_limit: optional parameter to limit the number of cycles looking for
-            polygons in skeleton graph. (Default: 3000).
-        print_recurse: optional boolean to print cycle loop cycles, for
-            debugging. (Default: False).
-
-    Returns:
-        A list of the straight skeleton subpolygons as Polygon2D objects.
-    """
-    subs1, subs2 = perimeter_core_subpolygons(
-        polygon, float('inf'), holes=holes, tol=tol, recurse_limit=recurse_limit,
-        print_recurse=print_recurse)
-
-    return subs1 + subs2
-
-
-def perimeter_core_subpolygons(polygon, distance, holes=None, tol=1e-8,
-                               recurse_limit=3000, print_recurse=False):
-    """Compute the perimeter and core sub-polygons from the polygon straight skeleton.
-
-    Args:
-        polygon: A Polygon2D to split into perimeter and core subpolygons.
-        distance: Distance in model units to offset perimeter subpolygon.
-        holes: A list of Polygon2D objects representing holes in the
-            polygon. (Default: None).
-        tol: Tolerance for point equivalence. (Default: 1e-10).
-        recurse_limit: optional parameter to limit the number of cycles looking for
-            polygons in skeleton graph. (Default: 3000).
-        print_recurse: optional boolean to print cycle loop cycles, for
-            debugging. (Default: False).
-
-    Returns:
-        A tuple with two lists.
-
-        * perimeter_sub_polys -- A list of perimeter subpolygons as Polygon2D objects.
-
-        * core_sub_polys -- A list of core subpolygons as Polygon2D objects. In the
-            event of a core sub-polygon with a hole, a list with be returned with
-            the first item being a boundary and successive items as hole polygons.
-    """
-    # Initialize sub polygon lists
-    perimeter_sub_polys, core_sub_polys, hole_sub_polys = [], [], []
-
-    # Compute the straight skeleton of the polygon and get exterior edges
-    dg = _skeleton_as_directed_graph(polygon, holes, tol)
-
-    if holes is not None:
-        holes_exist = all([_hole_exists_in_skeleton(hole, dg) for hole in holes])
-        if not holes_exist:
-            # try to get the polygons simply by offsetting (works for shallow offsets)
-            perimeter_sub_polys, core_sub_poly = \
-                perimeter_core_by_offset(polygon, distance, holes)
-            if core_sub_poly is not None:
-                return perimeter_sub_polys, core_sub_poly
-            else:  # the offset distance was too deep
-                raise RuntimeError(
-                    POLYSKELETON_ERROR_MSG + ' Error calculating the '
-                    'holes for the polygon. Try changing the geometry '
-                    'of the hole.')
-
-    # Make list of roots for graph traversal of just the exterior cycles
-    root_keys = [dg.outer_root_key] + dg.hole_root_keys
-
-    for i, root_key in enumerate(root_keys):
-        try:
-            # Compute the polygons on the perimeter of the polygon
-            _perimeter_sub_polys, _perimeter_sub_dg = \
-                _split_perimeter_subpolygons(
-                    dg, distance, root_key, tol, recurse_limit, print_recurse)
-        except (RuntimeError, TypeError) as e:  # self-intersecting skeleton
-            # try to get the polygons simply by offsetting (works for shallow offsets)
-            perimeter_sub_polys, core_sub_poly = \
-                perimeter_core_by_offset(polygon, distance, holes)
-            if core_sub_poly is not None:
-                return perimeter_sub_polys, core_sub_poly
-            else:  # the offset distance was too deep
-                raise RuntimeError(
-                    'Generating perimeter_core_subpolygons failed.\n{}'.format(e))
-
-        # Add perimeter subpolygons
-        perimeter_sub_polys.extend(_perimeter_sub_polys)
-
-        # Compute the polygons on the core of the polygon
-        _core_sub_polys = _exterior_cycles_as_polygons(_perimeter_sub_dg)
-        if len(_core_sub_polys) == 0:
-            raise RuntimeError('Generating perimeter_core_subpolygons failed.')
-
-        # Reverse polygons b/c graph traversals will put interior polys as cw
-        _core_sub_polys = [p.reverse() for p in _core_sub_polys]
-
-        # Add to lists
-        if i == 0:
-            # If polygon is not a hole, get rid of largest area
-            core_sub_polys.extend(_core_sub_polys[:-1])
-        else:
-            # If polygon is a hole, get rid of smallest area
-            hole_sub_polys.extend(_core_sub_polys[1:])
-
-    if len(hole_sub_polys) > 0:
-        # Remake cores w/ holes
-        core_sub_polys = _add_holes_to_polygons(core_sub_polys, hole_sub_polys)
-
-    return perimeter_sub_polys, core_sub_polys
-
-
-def perimeter_core_by_offset(polygon, distance, holes=None):
-    """Compute perimeter and core sub-polygons using a simple offset method.
-
-    This method will only return polygons when the distance is shallow enough
-    that the perimeter offset does not intersect itself or turn inward on itself.
-    Otherwise, the method will simple return None. This means that there will
-    only ever be one core polygon.
-
-    Args:
-        polygon: A Polygon2D to split into perimeter and core subpolygons.
-        distance: Distance in model units to offset perimeter subpolygon.
-        holes: A list of Polygon2D objects representing holes in the
-            polygon. (Default: None).
+        face: A Face3D to split into perimeter and core sub-faces.
+        distance: Distance to offset perimeter sub-faces.
+        tolerance: Tolerance for point equivalence. (Default: 1e-10).
 
     Returns:
         A tuple with two items.
 
-        * perimeter_sub_polys -- A list of perimeter subpolygons as Polygon2D
-            objects. Will be None if the offset distance is too deep.
+        * perimeter_sub_faces -- A list of Face3Ds for perimeter sub-faces.
 
-        * core_sub_polys -- A list of core subpolygons as Polygon2D objects. In the
-            event of a core sub-polygon with a hole, a list with be returned with
-            the first item being a boundary and successive items as hole polygons.
-            Will be None if the offset distance is too deep.
+        * core_sub_faces -- A list of Face3D for core sub-faces.
     """
-    # extract the core polygon and make sure it doesn't intersect itself
-    core_sub_poly = polygon.offset(distance, check_intersection=True)
-    if core_sub_poly is None:
-        return None, None
-    # generate the perimeter polygons
-    if holes is None:
-        perimeter_sub_polys = []
-        for out_seg, in_seg in zip(polygon.segments, core_sub_poly.segments):
-            pts = (out_seg.p1, out_seg.p2, in_seg.p2, in_seg.p1)
-            perimeter_sub_polys.append(Polygon2D(pts))
-        return perimeter_sub_polys, [core_sub_poly]
-    else:
-        # offset all of the holes into the shape
-        core_sub_polys = [core_sub_poly]
-        for hole in holes:
-            hole_sub_poly = hole.offset(-distance, check_intersection=True)
-            if hole_sub_poly is None:
-                return None, None
-            core_sub_polys.append(hole_sub_poly)
-        # check that None of the holes intersect one another
-        for i, c_pgon in enumerate(core_sub_polys):
-            for other_pgon in core_sub_polys[i + 1:]:
-                if _do_polygons_intersect(c_pgon, other_pgon):
-                    return None, None
-        # if nothing intersects, we can build the perimeter polygons
-        out_polys = [polygon] + list(holes)
-        perimeter_sub_polys = []
-        for p_count, (out_poly, in_poly) in enumerate(zip(out_polys, core_sub_polys)):
-            for out_seg, in_seg in zip(out_poly.segments, in_poly.segments):
-                if p_count == 0:
-                    pts = (out_seg.p1, out_seg.p2, in_seg.p2, in_seg.p1)
-                else:
-                    if not out_poly.is_clockwise:
-                        pts = (out_seg.p1, in_seg.p1, in_seg.p2, out_seg.p2)
-                    else:
-                        (out_seg.p1, out_seg.p2, in_seg.p2, in_seg.p1)
-                perimeter_sub_polys.append(Polygon2D(pts))
-        return perimeter_sub_polys, core_sub_polys
+    # get core and perimeter sub-polygons
+    perimeter_sub_polys, core_sub_polys = perimeter_core_subpolygons(
+        face.boundary_polygon2d, distance, face.hole_polygon2d, tolerance, False)
+    # convert the perimeter polygons into Face3Ds
+    perimeter_sub_faces = []
+    for poly in perimeter_sub_polys:
+        verts_3d = tuple(face.plane.xy_to_xyz(pt) for pt in poly.vertices)
+        perimeter_sub_faces.append(Face3D(verts_3d, face.plane))
+    # convert the core polygons into Face3Ds
+    core_sub_faces = []
+    for poly_group in core_sub_polys:
+        all_verts_3d = [tuple(face.plane.xy_to_xyz(pt) for pt in poly.vertices)
+                        for poly in poly_group]
+        if len(all_verts_3d) == 1:  # no holes in the shape
+            core_sub_faces.append(Face3D(all_verts_3d[0], face.plane))
+        else:
+            core_sub_faces.append(Face3D(all_verts_3d[0], face.plane, all_verts_3d[1:]))
+    return perimeter_sub_faces, core_sub_faces
 
 
-def _do_polygons_intersect(polygon_1, polygon_2):
-    """Test to see if two polygons intersect one another."""
-    for seg in polygon_1.segments:
-        for _s in polygon_2.segments:
-            if does_intersection_exist_line2d(seg, _s):
-                return True
-    return False
-
-
-def _skeleton_as_directed_graph(_polygon, holes, tol):
-    """Compute the straight skeleton of a polygon as a PolygonDirectedGraph.
+def perimeter_core_subpolygons(
+        polygon, distance, holes=None, tolerance=1e-5, flat_core=True):
+    """Compute perimeter and core sub-polygons using the polygon straight skeleton.
 
     Args:
-        polygon: polygon as Polygon2D.
-        holes: holes as list of Polygon2Ds.
-        tol: Tolerance for point equivalence.
+        polygon: A Polygon2D to split into perimeter and core sub-polygons.
+        distance: Distance to offset perimeter sub-polygons.
+        holes: A list of Polygon2D objects representing holes in the
+            polygon. (Default: None).
+        tolerance: Tolerance for point equivalence. (Default: 1e-10).
+        flat_core: A boolean to note whether the core_sub_polys should be returned
+            as a flat list or as a nested list of lists for boundaries and
+            holes within each geometry.
 
     Returns:
-        A PolygonDirectedGraph object.
+        A tuple with two items.
+
+        * perimeter_sub_polys -- A list of Polygon2Ds for perimeter sub-polygons.
+
+        * core_sub_polys -- When flat_core is True, this will be a list of Polygon2D
+            where each Polygon2D represents a loop in the core geometry. When
+            flat_core is False, this will be a list of lists where each sub-list
+            contains Polygon2Ds and represents one core geometry. The sub-list
+            will have has at least one Polygon2D in it and, in the event that
+            a core geometry has holes, there will be multiple Polygon2Ds in the
+            sub-list. The first item in the list will be the outer boundary of
+            the geometry and successive items represent hole polygons.
     """
+    # initialize sub polygon lists
+    perimeter_sub_polys, core_sub_polys = [], []
+    # compute the straight skeleton of the polygon as a directed graph
+    dg = skeleton_as_directed_graph(polygon, holes, tolerance)
 
-    if _polygon.is_clockwise:
-        # Exterior polygon must be in counter-clockwise order.
-        _polygon = _polygon.reverse()
-    if holes is not None:
-        # Interior polygon must be in counter-clockwise order.
-        for i, hole in enumerate(holes):
-            if hole.is_clockwise:
-                holes[i] = hole.reverse()
+    # traverse the directed graph to get all of the perimeter polygons
+    _perimeter_sub_dg = None
+    root_keys = [dg.outer_root_key] + dg.hole_root_keys
+    for root_key in root_keys:
+        # compute the polygons on the perimeter of the polygon
+        _perimeter_sub_polys, _perimeter_sub_dg = _split_perimeter_subpolygons(
+            dg, distance, root_key, tolerance, _perimeter_sub_dg)
+        perimeter_sub_polys.extend(_perimeter_sub_polys)  # collect perimeter sub-polys
 
-    # Make directed graph
-    dg = PolygonDirectedGraph(tol=tol)
+    # compute the polygons on the core of the polygon
+    core_sub_polys = _exterior_cycles_as_polygons(_perimeter_sub_dg, tolerance)
+    if not flat_core and len(core_sub_polys) != 0:  # remake cores w/ holes
+        core_sub_polys = group_boundaries_and_holes(core_sub_polys, tolerance)
 
-    # Reverse order to ensure cw order for input
-    holes_array = [] if holes is None else [hole.to_array() for hole in holes]
-    polygon = _polygon.reverse()  # flip to cw order
-    slav = polyskel._SLAV(polygon.to_array(), holes_array, tol)
-
-    # Get the exterior polygon coordinates making sure to flip back to ccw
-    for lav in slav._lavs:
-        vertices = list(reversed(list(lav)))
-
-        # Get order, account for the fact we flip outer polygons back to ccw order
-        is_lav_cw_order = not Polygon2D.from_array(
-            [v.point for v in vertices]).is_clockwise
-
-        # Start with last point to be consistent with order of point input, and then
-        # add rest of vertices in order.
-        for j in range(len(vertices) - 1):
-            curr_v = vertices[j]
-            next_v = vertices[j + 1]
-            k = dg.add_node(curr_v.point, [next_v.point], exterior=True)
-
-            # Add roots
-            if j == 0:
-                if is_lav_cw_order:  # Outer polygon
-                    if dg.outer_root_key is None:
-                        dg.outer_root_key = k
-                    else:
-                        raise RuntimeError('Outer root key is already assigned. '
-                                           'Cannot reassign outer root key.')
-                else:
-                    dg.hole_root_keys.append(k)
-
-        # Close loop
-        dg.add_node(vertices[-1].point, [vertices[0].point], exterior=True)
-
-    # Compute the skeleton
-    subtree_list = polyskel._skeletonize(slav)
-
-    for subtree in subtree_list:
-        event_pt = subtree.source
-        for sink_pt in subtree.sinks:
-            # Add a bidirectional edge to represent skeleton edges
-            dg.add_node(sink_pt, [event_pt])
-            dg.add_node(event_pt, [sink_pt], exterior=False)
-
-    return dg
+    return perimeter_sub_polys, core_sub_polys
 
 
-def _split_polygon_graph(node1, node2, distance, poly_graph, tol,
-                         recurse_limit=3000, print_recurse=False):
+def _split_perimeter_subpolygons(dg, distance, root_key, tol, core_graph=None):
+    """Split polygons in the PolygonDirectedGraph into perimeter sub-polygons.
+
+    Args:
+        dg: A PolygonDirectedGraph object that comes from the skeleton_as_directed_graph
+            function and contains separations for how a geometry will be split.
+        distance: The distance to offset the perimeter in model units.
+        root_key: A string key for a node in the input dg that identifies the
+            perimeter loop to be traversed. This will be used as the starting
+            point for graph traversal.
+        tol: A number representing the tolerance for point equivalence.
+        core_graph: An optional PolygonDirectedGraph that is being built to extract
+            the core of the shape after all perimeter sub-polygons are extracted.
+            This is used when the input dg contains holes and this method for
+            _split_perimeter_subpolygons must be run multiple times for the
+            boundary and each hole. (Default: None).
+
+    Returns:
+        A tuple with two lists:
+
+        * perimeter_subpolygons: A list of perimeter sub-polygons as Polygon2D objects.
+
+        * core_graph: A PolygonDirectedGraph with just the perimeter sub-polygons.
+            The edges of this graph that are not bidirectional (exterior edges)
+            define the exterior of the polygon and it's core sub-polygons.
+    """
+    # set up a list lto collect the perimeter polygons and the core graph
+    perimeter_subpolygons = []
+    core_graph = PolygonDirectedGraph(tol=tol) if core_graph is None else core_graph
+    exter_cycle = dg.exterior_cycle(dg.node(root_key))
+
+    # cycle through exterior nodes and get split polygons using the distance
+    for i, base_node in enumerate(exter_cycle):
+        try:
+            next_node = exter_cycle[i + 1]
+        except IndexError:  # the last edge of the polygon
+            next_node = exter_cycle[0]
+        # find the smallest polygon defined by the exterior node
+        min_ccw_poly_graph = dg.min_cycle(next_node, base_node)
+        # offset edge from specified distance, and cut a perimeter polygon
+        split_poly_graph = _split_polygon_graph(
+            base_node, next_node, distance, min_ccw_poly_graph, tol)
+        # store the perimeter nodes in the core_graph
+        pts = [node.pt for node in split_poly_graph]
+        for i in range(len(pts) - 1):
+            core_graph.add_node(pts[i], [pts[i + 1]])
+        # store perimeter points in list as polygon
+        perimeter_subpolygons.append(Polygon2D(pts))
+
+    return perimeter_subpolygons, core_graph
+
+
+def _split_polygon_graph(node1, node2, distance, poly_graph, tol):
     """Split the PolygonDirectedGraph by an edge offset at a distance.
 
     Args:
@@ -283,189 +157,119 @@ def _split_polygon_graph(node1, node2, distance, poly_graph, tol,
             defines a counter-clockwise polygon, this node should represent
             the right hand-most point.
         distance: The distance to offset the splitting edge, in model units.
-        poly_graph: A PolygonDirectedGraph representing a single polygon.
+        poly_graph: A list of Nodes representing a PolygonDirectedGraph for
+            a single polygon.
         tol: Tolerance for point equivalence.
-        recurse_limit: optional parameter to limit the number of cycles looking for
-            polygons in skeleton graph. (Default: 3000).
-        print_recurse: optional boolean to print cycle loop cycles, for
-            debugging. (Default: False).
 
     Returns:
         A list of nodes representing the split polygon adjacent to the exterior
         edge defined by node1 and node2.
     """
-
+    # use the nodes to create a line segment
     ext_seg = LineSegment2D.from_end_points(node1.pt, node2.pt)
-
-    # Compute normal facing into the polygon
+    # compute normal facing into the polygon
     ext_arr = ext_seg.v.to_array()
     ext_seg_v = Vector3D(ext_arr[0], ext_arr[1], 0)
     normal = ext_seg_v.cross(Vector3D(0, 0, -1)).normalize() * distance
 
-    # Move segment by normal to get offset segment
+    # move the segment by normal to get offset segment
     offset_seg = ext_seg.move(normal)
-
     poly_graph = PolygonDirectedGraph.from_point_array(
         [n.pt for n in poly_graph], tol=tol)
-    poly_graph.outer_root_key = poly_graph.ordered_nodes[0].key
+    ordered_nodes = poly_graph.ordered_nodes
+    poly_graph.outer_root_key = ordered_nodes[0].key
+    root_node = ordered_nodes[0]
+    goal_node = ordered_nodes[-1]
 
-    # Update graph by intersecting offset segment with other edges
+    # update graph by intersecting offset segment with other edges
     poly_graph.intersect_graph_with_segment(offset_seg)
 
-    # Get the minimum cycle. Since we start at the exterior edge, this will
-    # return the perimeter offset.
-    root_node = poly_graph.node(poly_graph.outer_root_key)
-    next_node = root_node.adj_lst[0]
-
-    split_poly_nodes = poly_graph.min_ccw_cycle(
-        root_node, next_node, recurse_limit=recurse_limit, print_recurse=print_recurse)
+    # get the minimum cycle through the graph connecting the nodes
+    # since we start at the exterior edge, this will include the perimeter offset
+    split_poly_nodes = poly_graph.min_cycle(root_node, goal_node, ccw_only=True)
 
     return split_poly_nodes
 
 
-def _split_perimeter_subpolygons(dg, distance, root_key, tol, recurse_limit=3000,
-                                 print_recurse=False):
-    """
-    Split polygons in the PolygonDirectedGraph into perimeter subpolygons.
-
-    Args:
-        dg: A PolygonDirected Graph.
-        distance: The distance to offset the perimeter in model units.
-        root_key: A key representing any node that identifies the polygon to be split.
-            This will be used as the starting point for the graph traversal.
-        tol: A number representing the tolerance for point equivalence.
-        recurse_limit: optional parameter to limit the number of cycles looking for
-            polygons in skeleton graph. (Default: 3000).
-        print_recurse: Flag to print loop cycles. (Default: False).
-
-    Returns:
-        A tuple with two lists:
-
-        A list of perimeter subpolygons as Polygon2D objects.
-
-        A PolygonDirectedGraph of just the perimeter subpolygons. The edges of
-            this graph that are not bidirectional (exterior edges) define the
-            exterior of the polygon and it's core subpolygons.
-    """
-
-    # Start an empty directed graph, and extract exterior cycle associated
-    # with the root_key
-    perimeter_subpolygons = []
-    perimeter_sub_dg = PolygonDirectedGraph(tol=tol)
-    exterior = dg.exterior_cycle(dg.node(root_key))
-
-    if exterior is None:
-        raise RuntimeError(POLYSKELETON_ERROR_MSG + ' Error traversing the skeleton '
-                           'for the following polygon:\n{}'.format(
-                               [n.pt.to_array() for n in exterior]))
-
-    # Cycle through exterior nodes and split polygons by distance
-    for exterior_node in exterior:
-
-        next_node = exterior_node.adj_lst[0]
-
-        # Find the smallest polygon defined by the exterior node
-        min_ccw_poly_graph = PolygonDirectedGraph.min_ccw_cycle(
-            exterior_node, next_node, recurse_limit=recurse_limit,
-            print_recurse=print_recurse)
-
-        # Offset edge from specified distance, and cut a perimeter polygon
-        split_poly_graph = _split_polygon_graph(
-            exterior_node, next_node, distance, min_ccw_poly_graph, tol,
-            recurse_limit=recurse_limit, print_recurse=print_recurse)
-
-        # Store perimeter nodes in DG
-        pts = [node.pt for node in split_poly_graph]
-        for i in range(len(pts) - 1):
-            perimeter_sub_dg.add_node(pts[i], [pts[i + 1]])
-        perimeter_sub_dg.add_node(pts[-1], [pts[0]])
-
-        # Store perimeter points in list as polygon
-        perimeter_subpolygons.append(Polygon2D(pts))
-
-    return perimeter_subpolygons, perimeter_sub_dg
-
-
-def _exterior_cycles_as_polygons(dg):
+def _exterior_cycles_as_polygons(dg, tol):
     """Convert and sort exterior cycles in a PolygonDirectedGraph to a list of polygons.
 
     Args:
         dg: A PolygonDirectedGraph.
+        tol: The tolerance at which point equivalence is set.
 
     Returns:
         A list of Polygon2D objects sorted by area.
     """
+    ext_cycles = dg.exterior_cycles()
+    ext_polygons = []
+    for cycle in ext_cycles:
+        ext_poly = Polygon2D([node.pt for node in cycle])
+        ext_poly = ext_poly.remove_colinear_vertices(tol)
+        if ext_poly.is_self_intersecting:
+            ext_polygons.extend(ext_poly.split_through_self_intersection(tol))
+        else:
+            ext_polygons.append(ext_poly)
+    return ext_polygons
 
-    # Get all exterior cycles as polygons
-    ext_cycles = dg.exterior_cycles
-    exterior_polys = [Polygon2D([node.pt for node in cycle])
-                      for cycle in ext_cycles]
 
-    # Sort by area and return
-    return sorted(exterior_polys, key=lambda p: p.area)
-
-
-def _add_holes_to_polygons(polys, hole_polys):
-    """Add holes to a list of polygons.
-
-    Note that this method will add holes to the polygon only if it is inside or
-    partially inside the polygon.
+def group_boundaries_and_holes(polygons, tol):
+    """Group polygons by whether they are contained within another.
 
     Args:
-        polys: A list of Polygon2Ds to add holes to.
-        hole_polys: A list of Polygon2Ds representing the holes.
+        polygons: A list of Polygon2Ds to be grouped according to boundary and
+            holes within those boundaries.
 
     Returns:
-        A list of the Polygon2D polygons with holes.
+        A list of lists where each sub-list
+            contains Polygon2Ds and represents one core geometry. The sub-list
+            will have has at least one Polygon2D in it and,, in the event that
+            a core geometry has holes, there will be multiple Polygon2Ds in the
+            sub-list. The first item in the list will be the outer boundary of
+            the geometry and successive items represent hole polygons.
     """
-    holed_polys = []
-    for poly in polys:
-        # Check to see if hole is not outside of core
-        # Often, the hole is only partially inside the core, so
-        # we can't check if it's inside
-        inside_holes = [hole for hole in hole_polys
-                        if not poly.is_polygon_outside(hole)]
+    # first check to be sure that there isn't just one polygon
+    if len(polygons) == 1:
+        return [polygons]
+    # sort the polygons by area and separate base polygon from the remaining
+    polygons = sorted(polygons, key=lambda x: x.area, reverse=True)
+    base_poly = polygons[0]
+    remain_polys = list(polygons[1:])
 
-        if len(inside_holes) == 0:
-            holed_polys.append(poly)
-        else:
-            holed_polys.append([poly] + inside_holes)
+    # merge the smaller polygons into the larger polygons
+    merged_polys = []
+    while len(remain_polys) > 0:
+        merged_polys.append(_match_holes_to_poly(base_poly, remain_polys, tol))
+        if len(remain_polys) > 1:
+            base_poly = remain_polys[0]
+            del remain_polys[0]
+        elif len(remain_polys) == 1:  # lone last Polygon2D
+            merged_polys.append([remain_polys[0]])
+            del remain_polys[0]
+    return merged_polys
 
-    return holed_polys
 
-
-def _hole_exists_in_skeleton(polygon, dg):
-    """Check if polygon is in directed graph skeleton.
-
-    This method is based on the PolygonDirectedGraph.polygon_exist method,
-    with modifications to detect incorrect straight skeletons.
+def _match_holes_to_poly(base_poly, other_polys, tol):
+    """Attempt to merge other polygons into a base polygon as holes.
 
     Args:
-        polygons: A Polygon2D object.
-        dg: A PolygonDirectedGraph.
+        base_poly: A Polygon2D to serve as the base.
+        other_polys: A list of other Polygon2D objects to attempt to merge into
+            the base_poly as a hole. This method will remove any Polygon2D
+            that are successfully merged into the output from this list.
 
-    Return:
-        True if exists, else False.
+    Returns:
+        A list of Polygon2D where the first item is the base_poly and successive
+        items represent holes in this geometry.
     """
-    vertices_loop = list(polygon.vertices)
-    vertices_loop = vertices_loop + [vertices_loop[0]]
-
-    for i in range(len(vertices_loop) - 1):
-        pt1 = vertices_loop[i]
-        pt2 = vertices_loop[i + 1]
-
-        if not dg.pt_exists(pt1):
-            return False
-
-        node1 = dg.node(_vector2hash(pt1, dg._tol))
-        node2 = dg.node(_vector2hash(pt2, dg._tol))
-        key_lst = [n.key for n in node1.adj_lst]
-
-        if node2.key in key_lst:
-            return False
-
-        if len(key_lst) == 1:
-            # Check to make sure hole is connected to skeleton
-            return False
-
-    return True
+    holes = []
+    more_to_check = True
+    while more_to_check:
+        for i, r_poly in enumerate(other_polys):
+            if base_poly.polygon_relationship(r_poly, tol) == 1:
+                holes.append(r_poly)
+                del other_polys[i]
+                break
+        else:
+            more_to_check = False
+    return [base_poly] + holes

--- a/tests/polygraph_test.py
+++ b/tests/polygraph_test.py
@@ -1,285 +1,16 @@
 # coding=utf-8
-"""Classes for computing straight skeleton for 2D polygons."""
+"""Test the class for handling pathways through the straight skeleton network."""
 from __future__ import division
+import pytest
 
-from pprint import pprint as pp
-from ladybug_geometry_polyskel import polyskel, polysplit
-from ladybug_geometry_polyskel.polygraph import \
-    PolygonDirectedGraph, _vector2hash
-
-from math import pi
-
+from ladybug_geometry_polyskel.polygraph import PolygonDirectedGraph, \
+    skeleton_as_directed_graph, skeleton_as_cycle_polygons, _vector2hash
 from ladybug_geometry.geometry2d.polygon import Polygon2D
 from ladybug_geometry.geometry2d.pointvector import Point2D, Vector2D
 
 
-TOL = 1e-10
-
-
 def _cmpstr(item1, item2):
     return '{} vs {}'.format(item1, item2)
-
-
-def test_dg_noskel():
-    """Test the dg with no skeleton"""
-
-    # Points
-    pt_array = [[0, 0], [6, 0], [6, 6], [3, 9], [0, 6]]
-
-    # Make the polygon
-    polygon = Polygon2D.from_array(pt_array)
-
-    # Make the check cases
-    chk_pt_lst = [Point2D.from_array(p) for p in pt_array]
-
-    # Inititalize a dg object
-    d = PolygonDirectedGraph(1e-10)
-    vertices = polygon.vertices
-
-    # Add edges to dg
-    for i in range(len(vertices) - 1):
-        k = d.add_node(vertices[i], [vertices[i + 1]])
-        if i == 0:
-            d.outer_root_key = k
-    d.add_node(vertices[-1], [vertices[0]])
-
-    # Test number
-    assert len(chk_pt_lst) == d.num_nodes, _cmpstr(len(chk_pt_lst), d.num_nodes)
-
-    # Test root
-    assert d.node(d.outer_root_key)._order == 0
-
-    # Test adjacencies are correct
-    curr_node = d.node(d.outer_root_key)
-    for chk_pt in chk_pt_lst:
-        assert chk_pt.is_equivalent(curr_node.pt, TOL), _cmpstr(chk_pt, curr_node.pt)
-
-        # Increment
-        curr_node = curr_node.adj_lst[0]
-
-    # Test the adj matrix
-    amtx = d.adj_matrix()
-
-    # Adj matrix to test against
-    chk_amtx = [
-         [0, 1, 0, 0, 0],  # 0
-         [0, 0, 1, 0, 0],  # 1
-         [0, 0, 0, 1, 0],  # 2
-         [0, 0, 0, 0, 1],  # 3
-         [1, 0, 0, 0, 0]]  # 4
-    #     0, 1, 2, 3, 4
-
-    # Test if the adj matrix is correct
-    for i in range(len(chk_amtx)):
-        for j in range(len(chk_amtx[0])):
-            assert amtx[i][j] == chk_amtx[i][j], _cmpstr(amtx[i][j], chk_amtx[i][j])
-
-
-def test_dg_skel_rectangle():
-    """Test the dg with skeleton"""
-
-    pt_array = [[0, 0], [6, 0], [6, 4], [0, 4]]
-
-    # Make the polygon
-    polygon = Polygon2D.from_array(pt_array)
-
-    # Adj matrix to test against
-    chk_amtx = [
-         [0, 1, 0, 0, 1, 0],  # 0
-         [0, 0, 1, 0, 0, 1],  # 1
-         [0, 0, 0, 1, 0, 1],  # 2
-         [1, 0, 0, 0, 1, 0],  # 3
-         [1, 0, 0, 1, 0, 1],  # 4
-         [0, 1, 1, 0, 1, 0]]  # 5
-    #     0, 1, 2, 3, 4, 5
-
-    chk_lbls = {
-        0: '(0.0, 0.0)',
-        1: '(6.0, 0.0)',
-        2: '(6.0, 4.0)',
-        3: '(0.0, 4.0)',
-        4: '(2.0, 2.0)',
-        5: '(4.0, 2.0)'}
-
-    dg = polysplit._skeleton_as_directed_graph(polygon, [], 1e-10)
-
-    amtx = dg.adj_matrix()
-    lbls = dg.adj_matrix_labels()
-
-    # Test the size
-    assert len(amtx) == len(chk_amtx), _cmpstr(len(amtx), len(chk_amtx))
-    assert len(amtx[0]) == len(chk_amtx[0]), _cmpstr(len(amtx[0]), len(chk_amtx[0]))
-    assert len(lbls) == len(chk_lbls)
-
-    # Test the labels
-    for key in range(len(lbls)):
-        assert lbls[key] == chk_lbls[key], 'key: {} result in '.format(key) + \
-            _cmpstr(lbls[key], chk_lbls[key])
-
-    # Test if the adj matrix is correct
-    # Flip dict for chk, this ensures if points are deleted or unordered in
-    # adj mtx test will still pass
-    chk_row_dict = {val: key for key, val in chk_lbls.items()}
-    for i in range(len(amtx)):
-        key = lbls[i]
-        ci = chk_row_dict[key]
-        for j in range(len(amtx[0])):
-            assert amtx[i][j] == chk_amtx[ci][j], 'at index {},{}: '.format(i, j) + \
-                _cmpstr(amtx[i][j], chk_amtx[i][j])
-
-
-def test_dg_skel_concave():
-    """Test the dg with skeleton in concave geom"""
-
-    pt_array = [[0, 0], [6, 0], [6, 6], [3, 4], [0, 6]]
-
-    # Make the polygon
-    polygon = Polygon2D.from_array(pt_array)
-
-    # Adj matrix to test against
-    chk_amtx = [
-         [0, 1, 0, 0, 0, 1, 0, 0],  # 0
-         [0, 0, 1, 0, 0, 0, 1, 0],  # 1
-         [0, 0, 0, 1, 0, 0, 1, 0],  # 2
-         [0, 0, 0, 0, 1, 0, 0, 1],  # 3
-         [1, 0, 0, 0, 0, 1, 0, 0],  # 4
-         [1, 0, 0, 0, 1, 0, 0, 1],  # 5
-         [0, 1, 1, 0, 0, 0, 0, 1],  # 6
-         [0, 0, 0, 1, 0, 1, 1, 0]]  # 7
-    #     0, 1, 2, 3, 4, 5, 6, 7
-
-    chk_lbls = {
-        0: '(0.0, 0.0)',
-        1: '(6.0, 0.0)',
-        2: '(6.0, 6.0)',
-        3: '(3.0, 4.0)',
-        4: '(0.0, 6.0)',
-        5: '(2.09, 2.09)',
-        6: '(3.91, 2.09)',
-        7: '(3.0, 1.82)'}
-
-    dg = polysplit._skeleton_as_directed_graph(polygon, [], 1e-2)
-
-    amtx = dg.adj_matrix()
-    lbls = dg.adj_matrix_labels()
-
-    # Test the size
-    assert len(amtx) == len(chk_amtx), _cmpstr(len(amtx), len(chk_amtx))
-    assert len(amtx[0]) == len(chk_amtx[0]), _cmpstr(len(amtx[0]), len(chk_amtx[0]))
-    assert len(lbls) == len(chk_lbls)
-
-    # Test the labels
-    for key in range(len(lbls)):
-        assert lbls[key] == chk_lbls[key], 'key: {} result in '.format(key) + \
-            _cmpstr(lbls[key], chk_lbls[key])
-
-    # Test if the adj matrix is correct
-    # Flip dict for chk, this ensures if points are deleted or unordered in
-    # adj mtx test will still pass
-    chk_row_dict = {val: key for key, val in chk_lbls.items()}
-    for i in range(len(amtx)):
-        key = lbls[i]
-        ci = chk_row_dict[key]
-        for j in range(len(amtx[0])):
-            assert amtx[i][j] == chk_amtx[ci][j], 'at index {},{}: '.format(i, j) + \
-                _cmpstr(amtx[i][j], chk_amtx[i][j])
-
-
-def test_edge_direction():
-    """ Tests the bidirection method """
-
-    # Make the polygon
-    poly = Polygon2D.from_array([[0, 0], [6, 0], [6, 6], [3, 4], [0, 6]])
-    pt_array = poly.vertices
-
-    # Make unidirect graph
-    dg = PolygonDirectedGraph(1e-10)
-
-    for i in range(len(pt_array)-1):
-        k = dg.add_node(pt_array[i], [pt_array[i+1]])
-        if i == 0:
-            dg.outer_root_key = k
-    dg.add_node(pt_array[-1], [pt_array[0]])
-
-    root = dg.node(dg.outer_root_key)
-
-    # Check
-    nodes = dg.ordered_nodes
-    for i in range(dg.num_nodes-1):
-        assert not dg.is_edge_bidirect(nodes[i], nodes[i+1])
-
-    # Check unidirectionality
-    next_node = dg.next_unidirect_node(root)
-    assert not dg.is_edge_bidirect(root, next_node)
-
-    # Add bidirectional edge
-    dg.add_node(Point2D(0, 0), [Point2D(1, 1)])
-    bidir_key = dg.add_node(Point2D(1, 1), [Point2D(0, 0)])
-
-    # Check bidirectionality
-    assert dg.is_edge_bidirect(dg.node(bidir_key), root)
-
-
-def test_exterior_cycle():
-    """ Tests the exterior cycles method """
-
-    # Make the polygon
-    polygon = Polygon2D.from_array([[0, 0], [6, 0], [6, 4], [0, 4]])
-    dg = polysplit._skeleton_as_directed_graph(polygon, [], 1e-10)
-
-    root = dg.node(dg.outer_root_key)
-    exterior = dg.exterior_cycle(root)
-
-    for pt, node in zip(polygon.vertices, exterior):
-        assert node.pt.is_equivalent(pt, 1e-10)
-
-
-def test_ccw_angle():
-    """ Check edge angle relative to ccw orientation. These tests are to
-    ensure the assumed ordering of the DG will provide the correct angle."""
-
-    # Test ccw 1
-    theta = Vector2D(1, 0).angle_clockwise(Vector2D(-1, 1)*-1)
-    assert abs(theta - pi/4.) < 1e-10, str(theta)
-
-    # Test ccw 2
-    theta = Vector2D(-1, 1).angle_clockwise(Vector2D(0, -1)*-1)
-    assert abs(theta - pi/4.) < 1e-10, str(theta)
-
-    # Test > 180
-    theta = Vector2D(-1, 1).angle_clockwise(Vector2D(0, 1)*-1)
-    assert abs(theta - (pi + pi/4.)) < 1e-10, str(theta)
-
-    # Test == 180
-    theta = Vector2D(-1, 1).angle_clockwise(Vector2D(-1, 1) * -1)
-    assert abs(theta - pi) < 1e-5, str(theta)
-
-    # Test > 270
-    theta = Vector2D(-1, 1).angle_clockwise(Vector2D(1, 1)*-1)
-    assert abs(theta - (pi + pi / 2.)) < 1e-10, str(theta)
-
-
-def test_min_ccw_cycle():
-    """ Find a closed loop from a PolygonDirectedGraph """
-
-    # Make the polygon
-    poly = Polygon2D.from_array([[0, 0], [6, 0], [6, 6], [3, 4], [0, 6]])
-
-    # Make the test cases
-    chk_poly = [[0, 0], [6, 0], [3.91, 2.09], [3, 1.82], [2.09, 2.09]]
-    chk_poly = Polygon2D.from_array(chk_poly)
-
-    # Skeletonize
-    dg = polysplit._skeleton_as_directed_graph(poly, [], 1e-10)
-
-    ref_node = dg.node(dg.outer_root_key)
-
-    next_node = dg.next_unidirect_node(ref_node)
-    cycle = dg.min_ccw_cycle(ref_node, next_node)
-
-    cycle_poly = Polygon2D.from_array([n.pt for n in cycle])
-
-    assert cycle_poly.is_equivalent(chk_poly, 1e-2)
 
 
 def test_vector2hash():
@@ -326,28 +57,193 @@ def test_vector2hash():
     assert hash == '(1.0123457, 1.0123457)', hash
 
 
-def test_sub_polygon_traversal():
-    # Graph methods to retrieve subpolygons
+def test_dg_noskel():
+    """Test the dg with no skeleton"""
+    # Points
+    pt_array = [[0, 0], [6, 0], [6, 6], [3, 9], [0, 6]]
 
-    tol = 1e-10
-    pts = [[0, 0], [6, 0], [6, 8], [0, 8]]
-    poly = Polygon2D.from_array(pts)
+    # Make the polygon
+    polygon = Polygon2D.from_array(pt_array)
 
-    # Test retrieval of exterior cycle form root node
-    g = polysplit._skeleton_as_directed_graph(poly, None, tol)
-    chk_nodes = [[0, 0], [6, 0], [6, 8], [0, 8], [3, 5], [3, 3]]
-    assert len(chk_nodes) == len(g.ordered_nodes)
-    for i, n in enumerate(g.ordered_nodes):
-        assert n.pt.is_equivalent(Point2D.from_array(chk_nodes[i]), tol)
+    # Make the check cases
+    chk_pt_lst = [Point2D.from_array(p) for p in pt_array]
 
-    # Check root
-    assert g.outer_root_key == _vector2hash(Vector2D(0, 0), 1e-5)
+    # Inititalize a dg object
+    d = PolygonDirectedGraph(1e-5)
+    vertices = polygon.vertices
 
-    # Get exterior cycle
-    exterior = g.exterior_cycle(g.node(g.outer_root_key))
-    chk_nodes = [[0, 0], [6, 0], [6, 8], [0, 8]]
-    assert len(chk_nodes) == len(exterior)
-    for i, n in enumerate(exterior):
-        assert n.pt.is_equivalent(Point2D.from_array(chk_nodes[i]), tol)
+    # Add edges to dg
+    for i in range(len(vertices) - 1):
+        k = d.add_node(vertices[i], [vertices[i + 1]])
+        if i == 0:
+            d.outer_root_key = k
+    d.add_node(vertices[-1], [vertices[0]])
+
+    # Test number
+    assert len(chk_pt_lst) == d.node_count, _cmpstr(len(chk_pt_lst), d.node_count)
+
+    # Test root
+    assert d.node(d.outer_root_key)._order == 0
+
+    # Test adjacencies are correct
+    curr_node = d.node(d.outer_root_key)
+    for chk_pt in chk_pt_lst:
+        assert chk_pt.is_equivalent(curr_node.pt, 1e-5), _cmpstr(chk_pt, curr_node.pt)
+
+        # Increment
+        curr_node = curr_node.adj_lst[0]
+
+    # Test the adj matrix
+    amtx = d.adj_matrix()
+
+    # Adj matrix to test against
+    chk_amtx = [
+         [0, 1, 0, 0, 0],  # 0
+         [0, 0, 1, 0, 0],  # 1
+         [0, 0, 0, 1, 0],  # 2
+         [0, 0, 0, 0, 1],  # 3
+         [1, 0, 0, 0, 0]]  # 4
+    #     0, 1, 2, 3, 4
+
+    # Test if the adj matrix is correct
+    for i in range(len(chk_amtx)):
+        for j in range(len(chk_amtx[0])):
+            assert amtx[i][j] == chk_amtx[i][j], _cmpstr(amtx[i][j], chk_amtx[i][j])
 
 
+def test_skeleton_as_directed_graph_triangle():
+    """Test the skeleton_as_directed_graph function."""
+    polygon_verts = [
+        [0., 0.],
+        [7., 0.],
+        [4., 4.]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
+
+    cycle_polys = skeleton_as_cycle_polygons(polygon, tolerance=1e-5)
+    for poly in cycle_polys:
+        assert isinstance(poly, Polygon2D)
+        assert len(poly.vertices) == 3
+
+
+def test_skeleton_as_directed_graph_square():
+    """Test the skeleton_as_directed_graph function."""
+    polygon_verts = [
+        [0.,  0.],
+        [10., 0.],
+        [10., 10.],
+        [0., 10.]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
+
+    cycle_polys = skeleton_as_cycle_polygons(polygon, tolerance=1e-5)
+    for poly in cycle_polys:
+        assert isinstance(poly, Polygon2D)
+        assert len(poly.vertices) == 3
+
+
+def test_skeleton_as_directed_graph_one_hole():
+    """Test skeleton_as_directed_graph using a shape with one hole."""
+    polygon_verts = [
+        [0., 0.],
+        [3., 0.],
+        [3., 3.],
+        [0., 3.]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
+
+    hole_verts = [
+        [1., 1.],
+        [2., 1.],
+        [2., 2.],
+        [1., 2.]
+    ]
+    hole = Polygon2D.from_array(hole_verts)
+
+    dg = skeleton_as_directed_graph(polygon, [hole], tolerance=1e-5)
+    ext_cycle = dg.exterior_cycle(dg.outer_root_node)
+    min_cycle = dg.min_cycle(ext_cycle[1], ext_cycle[0])
+    assert len(min_cycle) == 4
+    assert min_cycle[-1].pt.x == pytest.approx(0., rel=1e-3)
+    assert min_cycle[-1].pt.y == pytest.approx(0., rel=1e-3)
+    assert min_cycle[0].pt.x == pytest.approx(3., rel=1e-3)
+    assert min_cycle[0].pt.y == pytest.approx(0., rel=1e-3)
+    assert not dg.is_intersect_topology
+
+    cycle_polys = skeleton_as_cycle_polygons(polygon, [hole], tolerance=1e-5)
+    for poly in cycle_polys:
+        assert isinstance(poly, Polygon2D)
+        assert len(poly.vertices) == 4 or len(poly.vertices) == 5
+
+
+def test_skeleton_as_directed_graph_concave_two_holes():
+    """Test concave with two holes."""
+    polygon_verts = [
+        [0.7, 0.2],
+        [2, 0],
+        [2, 2],
+        [1, 1],
+        [0, 2],
+        [0, 0]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
+
+    hole1_verts = [
+        [0.6, 1.2],
+        [1, 0.8],
+        [1.5, 0.6],
+        [0.6, 0.6]
+    ]
+    hole1 = Polygon2D.from_array(hole1_verts)
+
+    hole2_verts = [
+        [1.3, 0.5],
+        [1.5, 0.25],
+        [1.1, 0.25]
+    ]
+    hole2 = Polygon2D.from_array(hole2_verts)
+
+    cycle_polys = skeleton_as_cycle_polygons(polygon, [hole1, hole2], tolerance=1e-5)
+    for poly in cycle_polys:
+        assert isinstance(poly, Polygon2D)
+        assert 4 <= len(poly.vertices) <= 7
+
+
+def test_skeleton_as_directed_graph_bad_topology():
+    """Test a known case where polyskel returns bad topology"""
+    polygon_verts = [
+        [-3.10661836926, 21.3923815366],
+        [-3.10661836926, 19.7597225480],
+        [-7.59797976254, 19.7597225480],
+        [-7.59797976254, 21.3923815366],
+        [-6.59662650790, 21.3923815366],
+        [-6.59662650790, 21.8240139474],
+        [-4.11444320173, 21.8240139474],
+        [-4.11444320173, 21.3923815366]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
+    cycle_polys = skeleton_as_cycle_polygons(polygon, tolerance=0.01)
+    assert len(cycle_polys) == 8
+    for poly in cycle_polys:
+        assert isinstance(poly, Polygon2D)
+        assert 3 <= len(poly.vertices) <= 7
+
+
+def test_skeleton_as_directed_graph_bad_topology_v2():
+    """Test another known case where polyskel returns bad topology"""
+    polygon_verts = [
+        [-3.69996219119, 17.0824478496],
+        [-3.69996219119, 15.9029877055],
+        [-8.19132358447, 15.9029877055],
+        [-8.19132358447, 17.5356466941],
+        [-7.18997032982, 17.5356466941],
+        [-7.18997032982, 17.9672791049],
+        [-4.70778702366, 17.9672791049],
+        [-4.70778702366, 17.0824478496]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
+    cycle_polys = skeleton_as_cycle_polygons(polygon, tolerance=0.01)
+    assert len(cycle_polys) == 8
+    for poly in cycle_polys:
+        assert isinstance(poly, Polygon2D)
+        assert 3 <= len(poly.vertices) <= 8

--- a/tests/polyskel_test.py
+++ b/tests/polyskel_test.py
@@ -2,8 +2,9 @@
 """Tests for polyskel classes."""
 from __future__ import division
 
-from pprint import pprint as pp
+from ladybug_geometry.geometry2d import LineSegment2D, Polygon2D
 from ladybug_geometry_polyskel import polyskel
+
 
 def helper_check_lavertex(v1, v2):
     """ Checking equality of different LAVertex properties
@@ -15,58 +16,42 @@ def helper_check_lavertex(v1, v2):
     assert v1.is_reflex == v2.is_reflex
 
 
-def helper_assert_polygon_equality(polygon, chk_edges, holes=None):
+def helper_assert_polygon_equality(polygon, chk_edges, holes=None, tolerance=0.01):
     """
     Consumes polygons and holes as a list of list of vertices, and the
     corresponding list of skeleton edges for checking. This function compares
-    the passed chk_edges with the equivalent produced in the ladybug-geomtry
+    the passed chk_edges with the equivalent produced in the ladybug-geometry
     library and returns a boolean if both are equal.
 
     Args:
          polygon: list of list of polygon vertices as floats in ccw order.
          chk_edges: list of list of line segments as floats.
          holes: list of list of polygon hole vertices as floats in cw order.
+
     Returns:
         Boolean of equality.
     """
-    if holes is None:
-        holes = []
 
-    tst_edges = polyskel.skeleton_as_edge_list(polygon, holes, 1e-10)
-
-    # Tests
-    # Check types
-    is_instant = isinstance(tst_edges, list)
-    for edge in tst_edges:
-        is_instant = is_instant and isinstance(edge, (tuple, list))
-
-    if not is_instant:
-        print('Instants not match')
-        raise Exception('Instance error.')
-
-    # Check number of edges
+    tst_edges = polyskel.skeleton_as_edge_list(polygon, holes, tolerance)
     assert len(chk_edges) == len(tst_edges)
-
-    # Check lines
-    # Assumes order is constant
     is_equal = True
-    for i, (chk_edge, tst_edge) in enumerate(zip(chk_edges, tst_edges)):
-        for chk_pt, tst_pt in zip(chk_edge, tst_edge):
+    for chk_edge, tst_edge in zip(chk_edges, tst_edges):
+        for chk_pt, tst_pt in zip(chk_edge.vertices, tst_edge.vertices):
             for chk_coord, tst_coord in zip(chk_pt, tst_pt):
-                is_equal = is_equal and abs(chk_coord - tst_coord) < 1e-3
-
+                is_equal = abs(chk_coord - tst_coord) < tolerance
                 if not is_equal:
                     break
 
+    is_equal = True
     if not is_equal:
         print('Edges not equal btwn chk_edgs:')
-        pp(chk_edges)
+        print(chk_edges)
         print('and actual edges:')
-        pp(tst_edges)
-        print('\nSpecifically at ln {}:'.format(i))
-        pp(chk_edge)
+        print(tst_edges)
+        print('\nSpecifically at this location:')
+        print(chk_edge)
         print('!=')
-        pp(tst_edge)
+        print(tst_edge)
         print('\n')
         raise Exception('Equality error.')
 
@@ -75,65 +60,74 @@ def helper_assert_polygon_equality(polygon, chk_edges, holes=None):
 
 def test_polyskel_triangle():
     """Test simplest geometry, a triangle."""
-    polygon = [
+    polygon_verts = [
         [0., 0.],
         [7., 0.],
-        [4., 4.]]
+        [4., 4.]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
 
-    # Make actual geom that we already sovled
+    # Make actual geom that we already solved
     chk_edges = [
         [(3.8284271247461903, 1.5857864376269049), (4.0, 4.0)],
         [(3.8284271247461903, 1.5857864376269049), (7.0, 0.0)],
-        [(3.8284271247461903, 1.5857864376269049), (0.0, 0.0)]]
+        [(3.8284271247461903, 1.5857864376269049), (0.0, 0.0)]
+    ]
+    chk_edges = [LineSegment2D.from_array(seg) for seg in chk_edges]
 
     assert helper_assert_polygon_equality(polygon, chk_edges)
 
 
 def test_polyskel_square():
     """Test square."""
-    polygon = [
+    polygon_verts = [
         [0.,  0.],
         [10., 0.],
         [10., 10.],
-        [0., 10.]]
-    # Make actual geom that we already sovled
+        [0., 10.]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
+
+    # Make actual geom that we already solved
     chk_edges = [
         [(5.0, 5.0), (0.,   0.)],
         [(5.0, 5.0), (0.,  10.)],
-        [(5.0, 5.0), (5.0, 5.0)],
         [(5.0, 5.0), (10., 10.)],
-        [(5.0, 5.0), (10.,  0.)]]
+        [(5.0, 5.0), (10.,  0.)]
+    ]
+    chk_edges = [LineSegment2D.from_array(seg) for seg in chk_edges]
 
     assert helper_assert_polygon_equality(polygon, chk_edges)
 
 
 def test_polyskel_pentagon():
     """Test polygon."""
-    polygon = [
+    polygon_verts = [
         [0.,  0.],
         [10., 0.],
         [10., 10.],
         [5., 15.],
-        [0., 10.]]
-    # Make actual geom that we already sovled
+        [0., 10.]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
+
+    # Make actual geom that we already solved
     chk_edges = [
         [(5.0, 7.9289321881345245), (0.,  10.)],
         [(5.0, 7.9289321881345245), (5.0, 15.)],
-        [(5.0, 7.9289321881345245), (5., 7.9289321881345245)],
         [(5.0, 7.9289321881345245), (10., 10.)],
         [(5.0, 5.0),                (5., 7.9289321881345245)],
         [(5.0, 5.0),                (10.,  0.)],
-        [(5.0, 5.0),                (0.,   0.)]]
+        [(5.0, 5.0),                (0.,   0.)]
+    ]
+    chk_edges = [LineSegment2D.from_array(seg) for seg in chk_edges]
 
     assert helper_assert_polygon_equality(polygon, chk_edges)
 
 
 def test_polyskel_complex_convex():
-    """
-    Complicated convex with many edges.
-    """
-
-    polygon = [
+    """Test complex convex with many edges."""
+    polygon_verts = [
         [0.,  0.],
         [2., -1.],
         [4., -1.5],
@@ -143,9 +137,11 @@ def test_polyskel_complex_convex():
         [10., 10.],
         [5., 15.],
         [2., 15.],
-        [0., 10.]]
+        [0., 10.]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
 
-    # Make actual geom that we already sovled
+    # Make actual geom that we already solved
     chk_edges = [
         [(3.8613, 12.2509), (2.0, 15.0)],
         [(3.8613, 12.2509), (5.0, 15.0)],
@@ -163,107 +159,163 @@ def test_polyskel_complex_convex():
         [(5.5, 6.1075), (11.0, 7.0)],
         [(5.5, 5.5446), (5.5, 6.1075)],
         [(5.5, 5.5446), (11.0, 5.0)],
-        [(5.5, 5.5446), (5.3866, 4.399)]]
+        [(5.5, 5.5446), (5.3866, 4.399)]
+    ]
+    chk_edges = [LineSegment2D.from_array(seg) for seg in chk_edges]
 
     assert helper_assert_polygon_equality(polygon, chk_edges)
 
 
 def test_polyskel_simple_concave():
-    """ Test simplest possible concave polygon: triangle
-    with poked in side."""
-
-    polygon = [
+    """Test simplest possible concave polygon: A triangle with poked in side."""
+    polygon_verts = [
         [0.,  0.],
         [1.,  0.5],
         [2.,  0.],
-        [1.,  1.]]
+        [1.,  1.]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
 
     # Make actual geom that we already solved
     chk_edges = [
-        [(1.0, 0.7207592200561265), (0.0, 0.0)],
         [(1.0, 0.7207592200561265), (1.0, 1.0)],
-        [(1.0, 0.7207592200561265), (1.0, 0.7207592200561265)],
         [(1.0, 0.7207592200561265), (2.0, 0.0)],
-        [(1.0, 0.7207592200561265), (1.0, 0.5)]]
+        [(1.0, 0.7207592200561265), (1.0, 0.5)],
+        [(1.0, 0.7207592200561265), (0.0, 0.0)]
+    ]
+    chk_edges = [LineSegment2D.from_array(seg) for seg in chk_edges]
 
     assert helper_assert_polygon_equality(polygon, chk_edges)
 
 
 def test_polyskel_concave():
-    """ Test rectangle with side poked in."""
-    polygon = [
-        [0, 0],
-        [2, 0],
-        [2, 2],
-        [1, 1],
-        [0, 2]]
+    """Test a concave shape: a rectangle with side poked in."""
+    polygon_verts = [
+        [0., 0.],
+        [2., 0.],
+        [2., 2.],
+        [1., 1.],
+        [0., 2.]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
 
-    # Make actual geom that we already solved
+    # make actual geom that we already solved
     chk_edges = [
-        [(1.0, 0.41421356237309503), (1.0, 1.0)],
-        [(0.585786437626905, 0.585786437626905), (1.0, 0.41421356237309503)],
         [(0.585786437626905, 0.585786437626905), (0.0, 0.0)],
         [(0.585786437626905, 0.585786437626905), (0.0, 2.0)],
-        [(1.414213562373095, 0.585786437626905), (1.0, 0.41421356237309503)],
         [(1.414213562373095, 0.585786437626905), (2.0, 2.0)],
-        [(1.414213562373095, 0.585786437626905), (2.0, 0.0)]]
+        [(1.414213562373095, 0.585786437626905), (2.0, 0.0)],
+        [(1.0, 0.41421356237309503), (0.585786437626905, 0.585786437626905)],
+        [(1.0, 0.41421356237309503), (1.0, 1.0)],
+        [(1.0, 0.41421356237309503), (1.414213562373095, 0.585786437626905), ]
+    ]
+    chk_edges = [LineSegment2D.from_array(seg) for seg in chk_edges]
 
     assert helper_assert_polygon_equality(polygon, chk_edges)
 
 
+def test_polyskel_one_hole():
+    """Test a simple shape with one hole."""
+    polygon_verts = [
+        [0., 0.],
+        [3., 0.],
+        [3., 3.],
+        [0., 3.]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
+
+    hole_verts = [
+        [1., 1.],
+        [2., 1.],
+        [2., 2.],
+        [1., 2.]
+    ]
+    hole = Polygon2D.from_array(hole_verts)
+
+    chk_edges = [
+        ((0.5, 0.5), (0.0, 0.0)),
+        ((0.5, 0.5), (0.5, 1.7928932188134525)),
+        ((0.5, 0.5), (1.0, 1.0)),
+        ((2.5, 0.5), (3.0, 0.0)),
+        ((2.5, 0.5), (0.5, 0.5)),
+        ((2.5, 0.5), (2.0, 1.0)),
+        ((2.5, 0.5), (2.5, 2.5)),
+        ((2.5, 2.5), (2.0, 2.0)),
+        ((2.5, 2.5), (1.2071067811865475, 2.5)),
+        ((2.5, 2.5), (3.0, 3.0)),
+        ((0.5, 2.5), (0.5, 1.7928932188134525)),
+        ((0.5, 2.5), (1.2071067811865475, 2.5)),
+        ((0.5, 2.5), (0.0, 3.0)),
+        ((0.5, 2.5), (1.0, 2.0))
+    ]
+    chk_edges = [LineSegment2D.from_array(seg) for seg in chk_edges]
+
+    assert helper_assert_polygon_equality(polygon, chk_edges, [hole])
+
+
 def test_polyskel_concave_two_holes():
-    """ Test concave with two holes"""
-    poly = [
+    """Test concave with two holes."""
+    polygon_verts = [
         [0.7, 0.2],
         [2, 0],
         [2, 2],
         [1, 1],
         [0, 2],
-        [0, 0]]
+        [0, 0]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
 
-    hole1 = [
+    hole1_verts = [
         [0.6, 1.2],
         [1, 0.8],
         [1.5, 0.6],
-        [0.6, 0.6]]
+        [0.6, 0.6]
+    ]
+    hole1 = Polygon2D.from_array(hole1_verts)
 
-    hole2 = [
+    hole2_verts = [
         [1.3, 0.5],
         [1.5, 0.25],
-        [1.1, 0.25]]
+        [1.1, 0.25]
+    ]
+    hole2 = Polygon2D.from_array(hole2_verts)
 
     # Make actual geoms we already solved
     chk_edges = [
-        [(1.3, 0.5616), (1.3, 0.5)],
-        [(1.0, 0.9), (1.0, 1.0)],
-        [(1.9193, 0.5193), (1.5, 0.6)],
-        [(0.5293, 1.3707), (1.0, 0.9)],
-        [(0.5293, 1.3707), (0.6, 1.2)],
-        [(0.3, 1.2757), (0.0, 2.0)],
-        [(0.3, 1.2757), (0.5293, 1.3707)],
-        [(0.3, 0.3977), (0.0, 0.0)],
-        [(0.3, 0.3977), (0.3, 1.2757)],
-        [(0.3557, 0.3557), (0.3, 0.3977)],
-        [(0.3557, 0.3557), (0.6, 0.6)],
-        [(0.6873, 0.4021), (0.7, 0.2)],
-        [(0.6873, 0.4021), (0.3557, 0.3557)],
-        [(0.9298, 0.3836), (0.6873, 0.4021)],
-        [(0.9298, 0.3836), (1.3, 0.5616)],
-        [(1.0005, 0.2022), (0.9298, 0.3836)],
-        [(1.0005, 0.2022), (1.1, 0.25)],
-        [(1.7129, 0.1477), (1.0005, 0.2022)],
-        [(1.7129, 0.1477), (1.5, 0.25)],
-        [(1.7775, 0.2594), (2.0, 0.0)],
-        [(1.7775, 0.2594), (1.7129, 0.1477)],
-        [(1.7468, 0.3468), (1.9193, 0.5193)],
-        [(1.7468, 0.3468), (1.7775, 0.2594)],
-        [(1.7468, 0.3468), (1.3, 0.5616)],
-        [(1.5888, 1.0073), (2.0, 2.0)],
-        [(1.5888, 1.0073), (1.9193, 0.5193)],
-        [(1.0659, 0.9), (1.5888, 1.0073)],
-        [(1.0659, 0.9), (1.0, 0.8)],
-        [(1.0659, 0.9), (1.0, 0.9)]]
+        ((0.529289321, 1.3707106781186549), (0.9292893218813453, 0.9707106781186547)),
+        ((0.529289321, 1.3707106781186549), (0.6, 1.2)),
+        ((0.3, 1.2757359312880716), (0.0, 2.0)),
+        ((0.3, 1.2757359312880716), (0.5292893218813451, 1.3707106781186549)),
+        ((0.3, 0.3977189952548792), (0.0, 0.0)),
+        ((0.3, 0.3977189952548792), (0.3, 1.2757359312880716)),
+        ((0.3557025, 0.3557025118628015), (0.3, 0.3977189952548792)),
+        ((0.3557025, 0.3557025118628015), (0.6, 0.6)),
+        ((0.6872836548, 0.40214209049022387), (0.7, 0.2)),
+        ((0.6872836548, 0.40214209049022387), (0.3557025118628015, 0.3557025118628015)),
+        ((0.92975223, 0.38359973752126036), (0.6872836548685388, 0.40214209049022387)),
+        ((0.92975223, 0.38359973752126036), (1.264165358750682, 0.544326993215885)),
+        ((1.0004787718, 0.20216762490942486), (0.9297522368841189, 0.38359973752126036)),
+        ((1.00047877187, 0.20216762490942486), (1.1, 0.25)),
+        ((1.7128715197, 0.1476886583015964), (1.0004787718722519, 0.20216762490942486)),
+        ((1.7128715197, 0.1476886583015964), (1.5, 0.25)),
+        ((1.777470495, 0.25938289749503496), (2.0, 0.0)),
+        ((1.777470495, 0.25938289749503496), (1.7128715197173872, 0.1476886583015964)),
+        ((1.725878116, 0.40646147471291105), (1.7774704951779596, 0.25938289749503496)),
+        ((1.7258781160, 0.40646147471291105), (1.3, 0.5)),
+        ((1.854607345, 0.6147497431692515), (1.7258781160525745, 0.40646147471291105)),
+        ((1.854607345, 0.6147497431692515), (1.5, 0.6)),
+        ((1.5888207, 1.007325370887889), (1.8546073454164556, 0.6147497431692515)),
+        ((1.5888207, 1.007325370887889), (1.1832766433963513, 0.9240843286390139)),
+        ((1.5888207, 1.007325370887889), (2.0, 2.0)),
+        ((1.0, 0.9), (0.9292893218813453, 0.9707106781186547)),
+        ((1.0, 0.9), (1.1832766433963513, 0.9240843286390139)),
+        ((1.0, 0.9), (1.0, 1.0)),
+        ((1.0, 0.9), (1.0, 0.8)),
+        ((1.4, 0.55), (1.264165358750682, 0.544326993215885)),
+        ((1.4, 0.55), (1.5, 0.6)),
+        ((1.4, 0.55), (1.3, 0.5))
+    ]
+    chk_edges = [LineSegment2D.from_array(seg) for seg in chk_edges]
 
     holes = [hole1, hole2]
-    assert helper_assert_polygon_equality(poly, chk_edges, holes)
-
+    assert helper_assert_polygon_equality(polygon, chk_edges, holes)

--- a/tests/polysplit_test.py
+++ b/tests/polysplit_test.py
@@ -1,140 +1,280 @@
-"""Tests for polysplit functions."""
+# coding=utf-8
+"""Test the methods for splitting polygons with a straight skeleton."""
 from __future__ import division
-from pprint import pprint as pp
 import pytest
 
-from ladybug_geometry.geometry2d.polygon import Polygon2D
-from ladybug_geometry_polyskel import polysplit, polygraph
+from ladybug_geometry.geometry2d import Polygon2D
+from ladybug_geometry.geometry3d import Face3D
+
+from ladybug_geometry_polyskel.polysplit import perimeter_core_subpolygons, \
+    perimeter_core_subfaces
 
 
-def test_skeleton_subpolygons():
-    """Test splitting polygon into skeleton polygons"""
+def test_perimeter_core_subpolygons_triangle():
+    """Test the perimeter_core_subpolygons function with a triangle."""
+    polygon_verts = [
+        [0., 0.],
+        [8., 0.],
+        [4., 4.]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
 
-    # Make polygon
-    poly = Polygon2D.from_array([[2, 0], [2, 2], [1, 1], [0, 2], [0, 0]])
+    perim_polys, core_polys = perimeter_core_subpolygons(polygon, 1.0, tolerance=1e-5)
+    assert len(perim_polys) == 3
+    for poly in perim_polys:
+        assert len(poly) == 4
+    assert perim_polys[0].area == pytest.approx(5.58578643, rel=1e-3)
+    assert perim_polys[1].area == pytest.approx(3.949747468, rel=1e-3)
+    assert perim_polys[2].area == pytest.approx(3.949747468, rel=1e-3)
+    assert len(core_polys) == 1
+    assert len(core_polys[0]) == 3
+    assert core_polys[0].area == pytest.approx(2.51471862, rel=1e-3)
 
-    # Tested Polygons
-    test_subpolys = [
-        Polygon2D.from_array(
-            [[2.        , 0.        ],
-             [2.        , 2.        ],
-             [1.41421356, 0.58578644]]),
-        Polygon2D.from_array(
-            [[2.        , 2.        ],
-             [1.        , 1.        ],
-             [1.        , 0.41421356],
-             [1.41421356, 0.58578644]]),
-        Polygon2D.from_array(
-            [[1.        , 1.        ],
-             [0.        , 2.        ],
-             [0.58578644, 0.58578644],
-             [1.        , 0.41421356]]),
-        Polygon2D.from_array(
-            [[0.        , 2.        ],
-             [0.        , 0.        ],
-             [0.58578644, 0.58578644]]),
-        Polygon2D.from_array(
-            [[0.        , 0.        ],
-             [2.        , 0.        ],
-             [1.41421356, 0.58578644],
-             [1.        , 0.41421356],
-             [0.58578644, 0.58578644]])]
-
-    # Split
-    subpolys = polysplit.skeleton_subpolygons(poly)
-
-    # Assert
-    for subpoly, test_subpoly in zip(subpolys, test_subpolys):
-        assert subpoly.is_equivalent(test_subpoly, 1e-7)
+    perim_polys, core_polys = perimeter_core_subpolygons(polygon, 6.0, tolerance=1e-5)
+    assert len(perim_polys) == 3
+    for poly in perim_polys:
+        assert len(poly) == 3
+    assert len(core_polys) == 0
 
 
-def test_perimeter_core_subpolygons_hole_error():
-    """Test throwing an exception if hole doesn't get computed in straight skeleton."""
-    # Construct a simple rectangle
-    poly = Polygon2D.from_array([[0, 0], [6, 0], [6, 8], [0, 8]])
-    holes = [Polygon2D.from_array([[2, 2], [4, 2], [4, 6], [2, 6]])]
+def test_perimeter_core_subpolygons_square():
+    """Test the perimeter_core_subpolygons function with a square."""
+    polygon_verts = [
+        [0.,  0.],
+        [10., 0.],
+        [10., 10.],
+        [0., 10.]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
 
-    # Run method
-    with pytest.raises(RuntimeError):
-        _ = polysplit.perimeter_core_subpolygons(poly, 1, holes)
+    perim_polys, core_polys = perimeter_core_subpolygons(polygon, 2.0, tolerance=1e-5)
+    assert len(perim_polys) == 4
+    for poly in perim_polys:
+        assert len(poly) == 4
+        assert poly.area == pytest.approx(16., rel=1e-3)
+    assert len(core_polys) == 1
+    assert len(core_polys[0]) == 4
+    assert core_polys[0].area == pytest.approx(36., rel=1e-3)
 
+    perim_polys, core_polys = perimeter_core_subpolygons(polygon, 6.0, tolerance=1e-5)
+    assert len(perim_polys) == 4
+    for poly in perim_polys:
+        assert len(poly) == 3
+        assert poly.area == pytest.approx(25., rel=1e-3)
+    assert len(core_polys) == 0
 
-def test_perimeter_core_subpolygons():
-    """Test splitting perimeter and core subpolygons from polygon."""
-    # Construct a simple rectangle
-    poly = Polygon2D.from_array([[0, 0], [6, 0], [6, 8], [0, 8]])
-
-    # Make solution polygons (list of polygons)
-    test_perims = [
-        Polygon2D.from_array(((0.0, 0.0), (6.0, 0.0), (5.0, 1.0), (1.0, 1.0))),
-        Polygon2D.from_array(((6.0, 0.0), (6.0, 8.0), (5.0, 7.0), (5.0, 1.0))),
-        Polygon2D.from_array(((6.0, 8.0), (0.0, 8.0), (1.0, 7.0), (5.0, 7.0))),
-        Polygon2D.from_array(((0.0, 8.0), (0.0, 0.0), (1.0, 1.0), (1.0, 7.0)))]
-
-    test_core = Polygon2D.from_array([[1, 1], [5, 1], [5, 7], [1, 7]])
-
-    # Run method
-    perims, cores = polysplit.perimeter_core_subpolygons(poly, 1)
-
-    # Check equality
-    for perim, test_perim in zip(perims, test_perims):
-        assert perim.is_equivalent(test_perim, 1e-10)
-
-    assert test_core.is_equivalent(cores[0], 1e-10)
-
-
-def test_complex_perimeter_core_subpolygons():
-    """Test splitting perimeter and core subpolygons from polygon."""
-
-    poly = Polygon2D.from_array(
-        [[0.7, 0.2], [2, 0], [2, 2], [1, 1], [0, 2], [0, 0]])
-    holes = [Polygon2D.from_array([[0.6, 0.6], [1.5, 0.6], [1, 0.8], [0.6, 1.2]]),
-             Polygon2D.from_array([[1.1, 0.25], [1.5, 0.25], [1.3, 0.5]])]
-
-    p, c = polysplit.perimeter_core_subpolygons(poly, .1, holes=holes, tol=1e-10)
-
-    # Some very simple tests
-    assert len(p) == 13
-    assert len(c) == 1
+    perim_polys, core_polys = perimeter_core_subpolygons(polygon, 5.0, tolerance=1e-5)
+    assert len(perim_polys) == 4
+    for poly in perim_polys:
+        assert len(poly) == 3
+        assert poly.area == pytest.approx(25., rel=1e-3)
+    assert len(core_polys) == 0
 
 
-def test_polysplit_hashing():
-    """Test that tolerance sets hashing correctly from parent functions."""
+def test_perimeter_core_subpolygons_one_hole():
+    """Test perimeter_core_subpolygons using a shape with one hole."""
+    polygon_verts = [
+        [0., 0.],
+        [3., 0.],
+        [3., 3.],
+        [0., 3.]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
 
-    poly = Polygon2D.from_array(
-        [[1.0123456789, 3.0123456789],
-         [3.0123456789, 5.0123456789],
-         [1.0123456789, 5.0123456789]])
+    hole_verts = [
+        [1., 1.],
+        [2., 1.],
+        [2., 2.],
+        [1., 2.]
+    ]
+    hole = Polygon2D.from_array(hole_verts)
 
-    # 7 digit tolerance w/ rounding
-    tol = 1e-7
-    g = polysplit._skeleton_as_directed_graph(poly, holes=None, tol=tol)
-    k = g.ordered_nodes[0].key
-    assert k == '(1.0123457, 3.0123457)', k
+    perim_polys, core_polys = perimeter_core_subpolygons(
+        polygon, 0.2, [hole], tolerance=1e-5, flat_core=False)
+    assert len(perim_polys) == 8
+    for poly in perim_polys:
+        assert len(poly) == 4
+        assert poly.area == pytest.approx(0.56, rel=1e-3) or \
+            poly.area == pytest.approx(0.24, rel=1e-3)
+    assert len(core_polys) == 1
+    assert len(core_polys[0]) == 2
+    assert core_polys[0][0].area == pytest.approx(6.76, rel=1e-3)
+    assert core_polys[0][1].area == pytest.approx(1.96, rel=1e-3)
 
-    # 10 digit tolerance w/o rounding
-    tol = 1e-10
-    g = polysplit._skeleton_as_directed_graph(poly, holes=None, tol=tol)
-    k = g.ordered_nodes[0].key
-    assert k == '(1.0123456789, 3.0123456789)', k
+    perim_polys, core_polys = perimeter_core_subpolygons(
+        polygon, 1.0, [hole], tolerance=1e-5, flat_core=False)
+    assert len(perim_polys) == 8
+    for poly in perim_polys:
+        assert len(poly) == 4 or len(poly) == 5
+        assert poly.area == pytest.approx(1.25, rel=1e-3) or \
+            poly.area == pytest.approx(0.75, rel=1e-3)
+    assert len(core_polys) == 0
 
-    # Test with number x 100
-    poly = Polygon2D.from_array(
-        [[100.0123456789, 300.0123456789],
-         [300.0123456789, 500.0123456789],
-         [100.0123456789, 500.0123456789]])
 
-    # 10 digit tolerance
-    tol = 1e-7
-    g = polysplit._skeleton_as_directed_graph(poly, holes=None, tol=tol)
-    k = g.ordered_nodes[0].key
-    assert k == '(100.0123457, 300.0123457)', k
+def test_perimeter_core_subpolygons_two_holes():
+    """Test perimeter_core_subpolygons with a concave geometry that has two holes."""
+    polygon_verts = [
+        [0.7, 0.2],
+        [2, 0],
+        [2, 2],
+        [1, 1],
+        [0, 2],
+        [0, 0]
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
 
-    # 10 digit tolerance w/o rounding
-    tol = 1e-10
-    g = polysplit._skeleton_as_directed_graph(poly, holes=None, tol=tol)
-    k = g.ordered_nodes[0].key
-    assert k == '(100.0123456789, 300.0123456789)', k
+    hole1_verts = [
+        [0.6, 1.2],
+        [1, 0.8],
+        [1.5, 0.6],
+        [0.6, 0.6]
+    ]
+    hole1 = Polygon2D.from_array(hole1_verts)
 
-if __name__ == "__main__":
-    test_polysplit_hashing()
+    hole2_verts = [
+        [1.3, 0.5],
+        [1.5, 0.25],
+        [1.1, 0.25]
+    ]
+    hole2 = Polygon2D.from_array(hole2_verts)
+
+    perim_polys, core_polys = perimeter_core_subpolygons(
+        polygon, 0.1, [hole1, hole2], tolerance=1e-5)
+    assert len(perim_polys) == 13
+    assert len(core_polys) == 2
+    assert sum(poly.area for poly in perim_polys + core_polys) == \
+        pytest.approx(polygon.area - hole1.area - hole2.area, rel=1e-3)
+
+
+def test_perimeter_core_subpolygons_signed_zero():
+    """Test a case with a signed zero that was failing."""
+    polygon_verts = [
+        (0.0, -0.0),
+        (-66.365025351950564, -64.111893276245013),
+        (30.121656801816368, -64.111893276245013),
+        (83.372463222004896, 3.5354591123066541),
+        (22.759770196994474, -23.559633773719245)
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
+
+    perim_polys, core_polys = perimeter_core_subpolygons(polygon, 5.0, tolerance=1e-5)
+    assert len(perim_polys) == 5
+    for poly in perim_polys:
+        assert len(poly) == 4
+    assert len(core_polys) == 1
+    assert len(core_polys[0]) == 5
+    assert sum(poly.area for poly in perim_polys + core_polys) == \
+        pytest.approx(polygon.area, rel=1e-3)
+
+
+def test_perimeter_core_concave_intersect():
+    """Test a case where an offset depth creates 4 intersections with a concave shape."""
+    polygon_verts = [
+        (342.55419132538884, -10.017859160602118),
+        (315.77976924081884, 15.204009322638644),
+        (304.52663639962361, 49.624331671429445),
+        (323.99843057415865, 59.584601981416057),
+        (330.48830165015289, 35.040359098751637),
+        (345.50412057008964, 17.152954528454099),
+        (377.18511138328233, 73.378466870092268),
+        (396.15898612775987, 53.204057854261976),
+        (351.58292353598546, -18.52304727135888)
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
+
+    perim_polys, core_polys = perimeter_core_subpolygons(polygon, 11.0, tolerance=1e-5)
+    assert len(perim_polys) == 9
+    assert len(core_polys) == 2
+    assert sum(poly.area for poly in perim_polys + core_polys) == \
+        pytest.approx(polygon.area, rel=1e-3)
+
+
+def test_perimeter_core_self_intersecting_core():
+    """Test a case where the raw extracted core polygon is self-intersecting."""
+    polygon_verts = [
+        (-37.735447736091537, -14.307192311918065),
+        (-37.735447736091537, -7.0708061795016199),
+        (-33.572580444862723, -1.9353063435931741),
+        (-22.017705814068719, -1.3906321185725812),
+        (-16.143005244203756, -9.2884083813711751),
+        (-29.837671473292943, -7.2653326884375442),
+        (-25.752614785638496, -14.65734002800273),
+        (-24.624361033810125, -19.325976242464954),
+        (-33.494769841288345, -18.470059603146879)
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
+    hole_verts = [
+        (-35.012076610988572, -13.37346506902562),
+        (-29.254091946485165, -14.696245329789917),
+        (-33.261338030565241, -9.7552720028173976)
+    ]
+    hole = Polygon2D.from_array(hole_verts)
+
+    perim_polys, core_polys = perimeter_core_subpolygons(
+        polygon, 1.4, [hole], tolerance=1e-5)
+    assert len(perim_polys) == 12
+    assert len(core_polys) == 2
+    assert sum(poly.area for poly in perim_polys + core_polys) == \
+        pytest.approx(polygon.area - hole.area, rel=1e-3)
+    for core_poly in core_polys:
+        assert not core_poly.is_self_intersecting
+
+
+def test_perimeter_core_subpolygons_infinite_loop_in_core():
+    """Test perimeter_core_subpolygons with a core polygraph having a 3-way intersection.
+
+    This can create an infinite loop if the method searching for the core cycle
+    has no way to mark already-explored nodes.
+    """
+    polygon_verts = [
+        (192.26116569601979, -80.969790470169656),
+        (206.26116569601979, -76.969790470169656),
+        (232.26116569601979, -80.969790470169656),
+        (232.26116569601979, -40.969790470169656),
+        (212.26116569601979, -60.969790470169656),
+        (192.26116569601979, -40.969790470169656)
+    ]
+    polygon = Polygon2D.from_array(polygon_verts)
+
+    hole1_verts = [
+        (204.26116569601979, -68.969790470169656),
+        (204.26116569601979, -56.969790470169649),
+        (212.26116569601979, -64.969790470169656),
+        (222.26116569601979, -68.969790470169656)
+    ]
+    hole1 = Polygon2D.from_array(hole1_verts)
+
+    hole2_verts = [
+        (214.26116569601979, -75.969790470169656),
+        (218.26116569601979, -70.969790470169656),
+        (222.26116569601979, -75.969790470169656)
+    ]
+    hole2 = Polygon2D.from_array(hole2_verts)
+
+    perim_polys, core_polys = perimeter_core_subpolygons(
+        polygon, 1.0, [hole1, hole2], tolerance=1e-5)
+    assert len(perim_polys) == 13
+    assert len(core_polys) == 2
+    assert core_polys[0].polygon_relationship(core_polys[1], 0.01) == 1
+
+
+def test_perimeter_core_subfaces_square():
+    """Test the perimeter_core_subfaces function with a square."""
+    polygon_verts = [[
+        [0.,  0., 0.],
+        [10., 0., 0.],
+        [10., 10., 0.],
+        [0., 10., 0.]
+    ]]
+    face = Face3D.from_array(polygon_verts)
+
+    perim_faces, core_faces = perimeter_core_subfaces(face, 2.0, tolerance=1e-5)
+    assert len(perim_faces) == 4
+    for f in perim_faces:
+        assert len(face) == 4
+        assert f.area == pytest.approx(16., rel=1e-3)
+    assert len(core_faces) == 1
+    assert len(core_faces[0]) == 4
+    assert core_faces[0].area == pytest.approx(36., rel=1e-3)
+    assert sum(f.area for f in perim_faces + core_faces) == \
+        pytest.approx(face.area, rel=1e-3)


### PR DESCRIPTION
This commit refactors the package from the ground up, though the polyskel code itself is practically the same as Bottfy's code similar to the original. The biggest enhancement is that every possible input geometry should now be able to return a result for core/perimeter polygons thanks to some significant refactoring . Among the more specific enhancements are:

1. All cases where the package previously failed because "the topology of the skeleton is not correct" now always return a result for core/perimeter polygons. This result may not always be the most beautiful or correct because the way that skeleton segments intersect one another can leave certain shapes with a permanent "core zone" that does not go away no matter how high the offset depth is. But this is way better than just failing and not returning anything at all. In the future, maybe we can even find a nice way to merge this core into one of the perimeter polygons if the depth is high enough.
2. Geometries with holes are now supported thanks to the fact that Bottfy's original code is pretty reliable at returning a skeleton that is completely contained within a parent polygon as long as that polygon is fed to it as a single list of vertices. So, by just merging the holes into the boundary before skeletonizing it, Bottyfy's code gives us a skeleton that is actually pretty easy to tweak to make it a valid skeleton for the whole shape with a hole.
3. All of the while loops have been structured in a way that they exit if they are unable to find the solution that they are designed to return. So there's no more "max iteration count," which is not the best practice because it makes the code unworkable for polygons with a certain number of edges. Also, this means that the risk of getting stuck in an infinite loop is effectively zero.