### PR TITLE
style(polygraph): Ensure negative coords less than tol get 0 and not -0

### DIFF
--- a/ladybug_geometry_polyskel/polygraph.py
+++ b/ladybug_geometry_polyskel/polygraph.py
@@ -32,8 +32,9 @@ def _vector2hash(vector, tol):
     else:  # tolerance is not base 10 (eg. 0.003)
         rtol += 1
     # avoid cases of signed zeros messing with the hash
-    x_val = 0.0 if vector.x == 0 else vector.x
-    y_val = 0.0 if vector.y == 0 else vector.y
+    z_tol = tol / 2
+    x_val = 0.0 if abs(vector.x) < z_tol else vector.x
+    y_val = 0.0 if abs(vector.y) < z_tol else vector.y
     # convert the coordinate values to a hash
     return str((
         base * round(x_val / base, rtol),


### PR DESCRIPTION
It seems like the "signed zero" issue is a little more complex than I thought given that you can have coordinate values like -0.002 and +0.002. Both of these should get a value of 0 in their coordinates hash if the tolerance is 0.01. But one will get a singed zero (-0) unless we do an extra check for this.